### PR TITLE
Fix extensions/ip_cloaking* not correctly telling the net about your changed hostname

### DIFF
--- a/extensions/ip_cloaking.c
+++ b/extensions/ip_cloaking.c
@@ -51,17 +51,17 @@ distribute_hostchange(struct Client *client_p, char *newhost)
 {
 	if (newhost != client_p->orighost)
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :is now your hidden host",
-			client_p->host);
+			newhost);
 	else
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :hostname reset",
-			client_p->host);
+			newhost);
 
 	sendto_server(NULL, NULL,
 		CAP_EUID | CAP_TS6, NOCAPS, ":%s CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 	sendto_server(NULL, NULL,
 		CAP_TS6, CAP_EUID, ":%s ENCAP * CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 
 	change_nick_user_host(client_p, client_p->name, client_p->username, newhost, 0, "Changing host");
 

--- a/extensions/ip_cloaking_3.0.c
+++ b/extensions/ip_cloaking_3.0.c
@@ -48,17 +48,17 @@ distribute_hostchange(struct Client *client_p, char *newhost)
 {
 	if (newhost != client_p->orighost)
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :is now your hidden host",
-			client_p->host);
+			newhost);
 	else
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :hostname reset",
-			client_p->host);
+			newhost);
 
 	sendto_server(NULL, NULL,
 		CAP_EUID | CAP_TS6, NOCAPS, ":%s CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 	sendto_server(NULL, NULL,
 		CAP_TS6, CAP_EUID, ":%s ENCAP * CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 
 	change_nick_user_host(client_p, client_p->name, client_p->username, newhost, 0, "Changing host");
 

--- a/extensions/ip_cloaking_4.0.c
+++ b/extensions/ip_cloaking_4.0.c
@@ -51,17 +51,17 @@ distribute_hostchange(struct Client *client_p, char *newhost)
 {
 	if (newhost != client_p->orighost)
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :is now your hidden host",
-			client_p->host);
+			newhost);
 	else
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :hostname reset",
-			client_p->host);
+			newhost);
 
 	sendto_server(NULL, NULL,
 		CAP_EUID | CAP_TS6, NOCAPS, ":%s CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 	sendto_server(NULL, NULL,
 		CAP_TS6, CAP_EUID, ":%s ENCAP * CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 
 	change_nick_user_host(client_p, client_p->name, client_p->username, newhost, 0, "Changing host");
 

--- a/extensions/ip_cloaking_old.c
+++ b/extensions/ip_cloaking_old.c
@@ -48,17 +48,17 @@ distribute_hostchange(struct Client *client_p, char *newhost)
 {
 	if (newhost != client_p->orighost)
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :is now your hidden host",
-			client_p->host);
+			newhost);
 	else
 		sendto_one_numeric(client_p, RPL_HOSTHIDDEN, "%s :hostname reset",
-			client_p->host);
+			newhost);
 
 	sendto_server(NULL, NULL,
 		CAP_EUID | CAP_TS6, NOCAPS, ":%s CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 	sendto_server(NULL, NULL,
 		CAP_TS6, CAP_EUID, ":%s ENCAP * CHGHOST %s :%s",
-		use_id(&me), use_id(client_p), client_p->host);
+		use_id(&me), use_id(client_p), newhost);
 
 	change_nick_user_host(client_p, client_p->name, client_p->username, newhost, 0, "Changing host");
 


### PR DESCRIPTION
They correctly set your hostname locally, but broadcasted your old hostname to the net, and also gave you the old hostname in the RPL_HOSTHIDDEN reply.  This fixes that.
