### PR TITLE
Adding auth_user documentation for auth {} blocks.

### DIFF
--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -326,6 +326,12 @@ auth {
 	user = "*@172.16.0.0/12";
 	user = "*test@123D:B567:*";
 
+	/* auth_user: This allows specifying a username:password instead of
+	 * just a password in PASS, so that a fixed user@host is not
+	 * necessary for a specific auth{} block.
+	 */
+	#auth_user = "SomeUser";
+
 	/* password: an optional password that is required to use this block.
 	 * By default this is not encrypted, specify the flag "encrypted" in
 	 * flags = ...; below if it is.


### PR DESCRIPTION
This is taking the description from NEWS and adding it into reference.conf
