### PR TITLE
Added quotes around a custom /part reason.

### DIFF
--- a/modules/core/m_part.c
+++ b/modules/core/m_part.c
@@ -133,8 +133,8 @@ part_one_client(struct Client *client_p, struct Client *source_p, char *name, ch
 	{
 
 		sendto_server(client_p, chptr, CAP_TS6, NOCAPS,
-			      ":%s PART %s :%s", use_id(source_p), chptr->chname, reason);
-		sendto_channel_local(ALL_MEMBERS, chptr, ":%s!%s@%s PART %s :%s",
+			      ":%s PART %s :\"%s\"", use_id(source_p), chptr->chname, reason);
+		sendto_channel_local(ALL_MEMBERS, chptr, ":%s!%s@%s PART %s :\"%s\"",
 				     source_p->name, source_p->username,
 				     source_p->host, chptr->chname, reason);
 	}


### PR DESCRIPTION
I added quotes around the /part reason when the user entered it.

This is so when someone removes someone from a channel it still looks like:
- mh0 has left #channel (requested by evilop (blah))

but when someone tried to "fake" a removal, with this patch it looks like:
- mh0 has left #channel ("requested by evilop (I'm faking this part message)")

This is good because then people can no longer dispute over whether someone was removed, or they were simply faking and trying to stir up trouble.
