### PR TITLE
Do not trim nicknames at ~

### DIFF
--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -123,19 +123,12 @@ mr_nick(struct Client *client_p, struct Client *source_p, int parc, const char *
 		return 0;
 	}
 
-	if(parc < 2 || EmptyString(parv[1]) || (parv[1][0] == '~'))
+	if(parc < 2 || EmptyString(parv[1]))
 	{
 		sendto_one(source_p, form_str(ERR_NONICKNAMEGIVEN),
 			   me.name, EmptyString(source_p->name) ? "*" : source_p->name);
 		return 0;
 	}
-
-	/* due to the scandinavian origins, (~ being uppercase of ^) and ~
-	 * being disallowed as a nick char, we need to chop the first ~
-	 * instead of just erroring.
-	 */
-	if((s = strchr(parv[1], '~')))
-		*s = '\0';
 
 	/* copy the nick and terminate it */
 	rb_strlcpy(nick, parv[1], ConfigFileEntry.nicklen);
@@ -183,18 +176,11 @@ m_nick(struct Client *client_p, struct Client *source_p, int parc, const char *p
 	char nick[NICKLEN];
 	char *s;
 
-	if(parc < 2 || EmptyString(parv[1]) || (parv[1][0] == '~'))
+	if(parc < 2 || EmptyString(parv[1]))
 	{
 		sendto_one(source_p, form_str(ERR_NONICKNAMEGIVEN), me.name, source_p->name);
 		return 0;
 	}
-
-	/* due to the scandinavian origins, (~ being uppercase of ^) and ~
-	 * being disallowed as a nick char, we need to chop the first ~
-	 * instead of just erroring.
-	 */
-	if((s = strchr(parv[1], '~')))
-		*s = '\0';
 
 	/* mark end of grace period, to prevent nickflooding */
 	if(!IsFloodDone(source_p))


### PR DESCRIPTION
I suggest to remove the special handling of `~` in nicknames. It's 2013, nobody uses ISO-646 anymore, and the code comment is not even true. (See commit message for more details.)
