### PR TITLE
Document MONITOR in /help

### DIFF
--- a/help/opers/index
+++ b/help/opers/index
@@ -4,21 +4,21 @@ ACCEPT          ADMIN           AWAY            CAPAB
 CHALLENGE       CHANTRACE       CLOSE           CMODE
 CNOTICE         CONNECT         CPRIVMSG        CREDITS
 DIE             DLINE           ERROR           ETRACE
-HELP            INDEX           INFO            INVITE
-EXTBAN          ISON            JOIN            KICK
+EXTBAN          HELP            INDEX           INFO
+INVITE          ISON            JOIN            KICK
 KILL            KLINE           KNOCK           LINKS
 LIST            LOCOPS          LUSERS          MAP
 MASKTRACE       MODLIST         MODLOAD         MODRELOAD
-MODRESTART      MODUNLOAD       MOTD            NAMES
-NICK            NOTICE          OPER            OPERSPY
-OPERWALL        PART            PASS            PING
-PONG            POST            PRIVMSG         QUIT
-REHASH          RESTART         RESV            SCAN
-SERVER          SET             SJOIN           SNOMASK
-SQUIT           STATS           SVINFO          TESTGECOS
-TESTLINE        TESTMASK        TIME            TOPIC
-TRACE           UHELP           UMODE           UNDLINE
-UNKLINE         UNREJECT        UNRESV          UNXLINE
-USER            USERHOST        USERS           VERSION
-WALLOPS         WHO             WHOIS           WHOWAS
-XLINE
+MODRESTART      MODUNLOAD       MONITOR         MOTD
+NAMES           NICK            NOTICE          OPER
+OPERSPY         OPERWALL        PART            PASS
+PING            PONG            POST            PRIVMSG
+QUIT            REHASH          RESTART         RESV
+SCAN            SERVER          SET             SJOIN
+SNOMASK         SQUIT           STATS           SVINFO
+TESTGECOS       TESTLINE        TESTMASK        TIME
+TOPIC           TRACE           UHELP           UMODE
+UNDLINE         UNKLINE         UNREJECT        UNRESV
+UNXLINE         USER            USERHOST        USERS
+VERSION         WALLOPS         WHO             WHOIS
+WHOWAS          XLINE

--- a/help/opers/monitor
+++ b/help/opers/monitor
@@ -1,0 +1,27 @@
+MONITOR <action> [nick[,nick]*]
+
+Manages the online-notification list (similar to WATCH elsewhere). The
+<action> must be a single character, one of:
+
+  +   adds the given list of nicknames to the monitor list, returns
+      each given nickname's status as RPL_MONONLINE or RPL_MONOFFLINE
+      numerics
+
+  -   removes the given list of nicknames from the monitor list, does
+      not return anything
+  
+  C   clears the monitor list, does not return anything
+  
+  L   returns the current monitor list as RPL_MONLIST numerics,
+      terminated with RPL_ENDOFMONLIST
+
+  S   returns status of each monitored nickname, as RPL_MONONLINE or
+      RPL_MONOFFLINE numerics
+
+For example:
+
+  MONITOR + jilles,kaniini,tomaw
+
+RPL_MONONLINE numerics return a comma-separated list of nick!user@host
+items. RPL_MONOFFLINE and RPL_MONLIST numerics return a comma-separated
+list of nicknames.

--- a/help/users/index
+++ b/help/users/index
@@ -5,10 +5,10 @@ CMODE           CNOTICE         CPRIVMSG        CREDITS
 ERROR           EXTBAN          HELP            INDEX
 INFO            INVITE          ISON            JOIN
 KICK            KNOCK           LINKS           LIST
-LUSERS          MAP             MOTD            NAMES
-NICK            NOTICE          OPER            PART
-PASS            PING            PONG            PRIVMSG
-QUIT            STATS           TIME            TOPIC
-TRACE           UMODE           USER            USERHOST
-USERS           VERSION         WHO             WHOIS
-WHOWAS
+LUSERS          MAP             MONITOR         MOTD
+NAMES           NICK            NOTICE          OPER
+PART            PASS            PING            PONG
+PRIVMSG         QUIT            STATS           TIME
+TOPIC           TRACE           UMODE           USER
+USERHOST        USERS           VERSION         WHO
+WHOIS           WHOWAS


### PR DESCRIPTION
I keep whining that `MONITOR` exists as a command but the only documentation (`doc/monitor.txt`) is not available through `HELP MONITOR`. Might as well fix that.
