### PR TITLE
Remove CHARSET=ascii from ISUPPORT

### DIFF
--- a/src/supported.c
+++ b/src/supported.c
@@ -329,7 +329,6 @@ init_isupport(void)
 	add_isupport("STATUSMSG", isupport_string, "@+");
 	add_isupport("CALLERID", isupport_umode, "g");
 	add_isupport("CASEMAPPING", isupport_string, "rfc1459");
-	add_isupport("CHARSET", isupport_string, "ascii");
 	add_isupport("NICKLEN", isupport_nicklen, NULL);
 	add_isupport("MAXNICKLEN", isupport_intptr, &maxnicklen);
 	add_isupport("CHANNELLEN", isupport_intptr, &channellen);


### PR DESCRIPTION
For one, [draft-brocklesby-irc-isupport-02](https://tools.ietf.org/html/draft-brocklesby-irc-isupport-02#section-3.17) already defines "ascii" as the default value. According to section 2 ("Except as explicitly stated in its definition, a parameter should not be sent unless it changes this default value, or the default value is vague, badly defined, or differs between IRC server implementations"), there is no point in sending it.

For another, [version 03 of the same draft](https://tools.ietf.org/html/draft-brocklesby-irc-isupport-03#section-4.8) removes CHARSET ("It was found to be unworkable;  a correct specification could not be devised to represent its meaning across implementations."), and the token is not present at all in [draft-hardy-irc-isupport-00](https://tools.ietf.org/html/draft-hardy-irc-isupport-00).

I haven't found any clients that actually care about CHARSET (they just apply the user-configured charset/encoding to both user-sent and ircd-generated messages), and it even confuses users who see the ircd reporting "ascii" but other users sending messages in UTF-8 and other charsets. I don't think there is any reason to keep such old junk in ISUPPORT anymore.

It seems that this token was added to ircd-ratbox in r13582, even though the commit message doesn't mention it.
