### PR TITLE
libratbox/crypt: fix difference from glibc in sha256_crypt()

### DIFF
--- a/libratbox/src/crypt.c
+++ b/libratbox/src/crypt.c
@@ -1567,7 +1567,7 @@ static char *rb_sha256_crypt_r(const char *key, const char *salt, char *buffer, 
 	rb_sha256_init_ctx(&alt_ctx);
 
 	/* For every character in the password add the entire password.  */
-	for (cnt = 0; cnt < (size_t)(16 + alt_result[0]); ++cnt)
+	for (cnt = 0; cnt < key_len; ++cnt)
 		rb_sha256_process_bytes(key, key_len, &alt_ctx);
 
 	/* Finish the digest.  */


### PR DESCRIPTION
rb_crypt() was generating different SHA256 ($5$) hashes than glibc, making hashes generated with charybdis unusable in ratbox and other software, and vice versa.

This commit breaks compatibility with old hashes instead. I'm not sure what would be the best way to avoid that – a different salt prefix, getenv(), or just force everyone to create new hashes. (The latter would cause trouble for people trying to share configs between charybdis 3.4 and 3.5…)

```
> perl -E 'say crypt(q[test], q[$5$saltsaltsaltsalt$])'
$5$saltsaltsaltsalt$ns1qn7Qw36aqLkRgHn2SRKz9BrteaAovM.XRJXVT5ND # good hash

> ~/src/charybdis/tools/mkpasswd -x -s saltsaltsaltsalt -p test
$5$saltsaltsaltsalt$hiBh8OP2wXRid8jcYmysIaXgduxVKcGR2cObNJ3Hed. # bad hash
```

/cc @elizacat, who broke it in the first place [[1]](https://github.com/atheme/charybdis/commit/48dc39f771b0c8a41ad91101c85ed5c2680dd939#diff-fbca4615b1278269f3bc76d132a25f1cL1567)
