### PR TITLE
helpfiles: fix spelling, grammar remove old information

### DIFF
--- a/help/opers/chantrace
+++ b/help/opers/chantrace
@@ -1,6 +1,6 @@
 CHANTRACE <#channel>
 
-Outputs a list of members in #channel in ETRACE format, with the classname
+Outputs a list of members in #channel in ETRACE format, with the class name
 replaced by the server the users are on.
 
 You must be a member of the channel to perform this command.

--- a/help/opers/cmode
+++ b/help/opers/cmode
@@ -9,7 +9,7 @@ NO PARAMETERS:
      +s     - Secret.  Channel will not be shown in /whois and /list etc.
      +p     - Private.  Disables /knock to the channel.
      +m     - Moderated.  Only opped/voiced users may talk in channel.
-     +i     - Invite only.  Users need to be /invite'd or match a +I to
+     +i     - Invite only.  Users need to be invited or match a +I to
               join the channel.
      +r     - Registered users only.  Only users identified to services
               may join.

--- a/help/opers/connect
+++ b/help/opers/connect
@@ -1,7 +1,7 @@
 CONNECT <server_A> [port] [server_B]
 
 When [server_B] is used, CONNECT asks [server_B] to
-connect to <server_A>.  Requires Oper Priv: R
+connect to <server_A>.  Requires Oper Priv: oper:routing
 
 The [port] must be specified with [server_B], this is
 usually 6667.  To use the default port in the connect

--- a/help/opers/credits
+++ b/help/opers/credits
@@ -5,6 +5,7 @@ Help files were written by the following people:
 disasta    David Daley        <disasta@go.com>
 Hwy101     W. Campbell        <wcampbel@botbay.net>
 larne      Edward Brocklesby  <ejb@leguin.org.uk>
+lyska      Sam Dodrill        <shadowh511@gmail.com>
 MoeBass    anonymous          <moe@moebass.com>
 screwedup  Jonathan Roes      <jroes@magenet.net>
 zartik     Daniel Hemmerich   <dan@spot.org>

--- a/help/opers/die
+++ b/help/opers/die
@@ -1,5 +1,7 @@
-DIE server.name
+DIE server.name [server.name]
 
-Terminates the IRC server
+Terminates the IRC server. If a second server name
+is provided, remotely terminate that server. In this
+case, both server names must match.
 
-- Requires Oper Priv: D
+- Requires Oper Priv: oper:die

--- a/help/opers/dline
+++ b/help/opers/dline
@@ -3,7 +3,7 @@ DLINE [duration] <ip> :[reason] [| oper reason]
 Adds a DLINE to the database which will deny any
 connections from the IP address of the banned client.
 The banned client will receive a message saying
-he/she is banned with reason [reason].
+they are banned with reason [reason].
 
 Duration is optional, and is in minutes. If specified,
 the DLINE will not be saved in the database.
@@ -17,4 +17,4 @@ DLINE [duration] <ip> ON irc.server :[reason] [| oper reason]
 will dline the user on irc.server if irc.server accepts
 remote dlines. irc.server can contain wildcards.
 
-- Requires Oper Priv: K
+- Requires Oper Priv: oper:kline

--- a/help/opers/kill
+++ b/help/opers/kill
@@ -3,5 +3,5 @@ KILL <nick> <reason>
 Disconnects user <nick> from the IRC server he/she
 is connected to with reason <reason>.
 
-- Requires Oper Priv: C
-- Requires Oper Priv: O for users not on your IRC server
+- Requires Oper Priv: oper:local_kill
+- Requires Oper Priv: oper:global_kill for users not on your IRC server

--- a/help/opers/kline
+++ b/help/opers/kline
@@ -23,4 +23,4 @@ KLINE [duration] <user@host> ON irc.server :[reason] [| oper reason]
 will kline the user on irc.server if irc.server accepts
 remote klines. irc.server can contain wildcards.
 
-- Requires Oper Priv: K
+- Requires Oper Priv: oper:kline

--- a/help/opers/locops
+++ b/help/opers/locops
@@ -1,4 +1,4 @@
 LOCOPS :<message>
 
-Sends an LOCOPS message of <message> to all
+Sends a LOCOPS message of <message> to all
 opers on local server who are umode +l

--- a/help/opers/modlist
+++ b/help/opers/modlist
@@ -1,8 +1,14 @@
-MODLIST [match string]
+MODLIST [match string] [server.name]
 
 -- List the modules that are currently loaded into the
 ircd, along with their address and version.
 When a match string is provided, modlist only prints
 modules with names matching the match string.
 
-- Requires Oper Priv: A
+A server name may also be provided to list currently
+loaded modules on that server if you have the modules
+shared priv on that server. If you're doing modlist
+on a remote server, a match string is required, but *
+will list all modules.
+
+- Requires Oper Priv: oper:admin

--- a/help/opers/modload
+++ b/help/opers/modload
@@ -1,8 +1,13 @@
-MODLOAD <[path/]module.so>
+MODLOAD <[path/]module.so> [server.name]
 
 -- Load a module into the ircd
 the optional path can be an absolute path
 from / or from the IRCD_PREFIX
 (ie modules/autoload/m_users.so)
 
-- Requires Oper Priv: A
+A server name may also be provided to load a module
+on a remote server if you have the modules shared priv
+on that server. Wildcards for server name may also be
+used to load a module on multiple servers.
+
+- Requires Oper Priv: oper:admin

--- a/help/opers/modreload
+++ b/help/opers/modreload
@@ -1,6 +1,11 @@
-MODRELOAD <module.so>
+MODRELOAD <module.so> [server.name]
 
 -- Reload a module in the ircd
 Use just the module name, the path is not needed.
 
-- Requires Oper Priv: A
+A server name may also be provided to reload a module
+on a remote server if you have the modules shared priv
+on that server. Wildcards for server name may also be
+used to reload a module on multiple servers.
+
+- Requires Oper Priv: oper:admin

--- a/help/opers/modrestart
+++ b/help/opers/modrestart
@@ -1,7 +1,12 @@
-MODRESTART
+MODRESTART [server.name]
 
 -- Reload all modules into the ircd
 All modules are unloaded, then those in modules/autoload
 are loaded
 
-- Requires Oper Priv: A
+A server name may also be provided to reload all modules
+on a remote server if you have the modules shared priv
+on that server. Wildcards for server name may also be
+used to reload all modules on multiple servers.
+
+- Requires Oper Priv: oper:admin

--- a/help/opers/modunload
+++ b/help/opers/modunload
@@ -1,8 +1,13 @@
-MODUNLOAD <module.so>
+MODUNLOAD <module.so> [server.name]
 
 -- Unload a module from the ircd
 Use just the module name, the path is not needed.
 When a module is unloaded, all commands associated
 with it are unloaded as well.
 
-- Requires Oper Priv: A
+A server name may also be provided to unload a module
+from a remote server if you have the modules shared priv 
+on that server. Wildcards for server name may also be used 
+to unload a module from multiple servers.
+
+- Requires Oper Priv: oper:admin

--- a/help/opers/operspy
+++ b/help/opers/operspy
@@ -1,11 +1,11 @@
 OPERSPY
 
 Opers with the "oper_spy" flag will be allowed uses of the following
-commands if they are compiled in.  Usage will be sent to +Z and all 
+commands if they are compiled in.  Usage will be sent to +Z and all
 other servers.
 
 whois !nick     - Gives a full output of channels the user is in.
-who !mask       - Lists all users networkwide whose nick, ident, host,
+who !mask       - Lists all users on the network whose nick, ident, host,
                   server or gecos match the mask.
 who !#channel   - Gives a full output of users on the channel.
 mode !#channel  - Gives the full modes of a channel including any keys.

--- a/help/opers/operwall
+++ b/help/opers/operwall
@@ -3,4 +3,4 @@ OPERWALL :<message>
 Sends an OPERWALL message of <message> to all
 opers who are umode +z
 
-- Requires Oper Priv: L
+- Requires Oper Priv: oper:operwall

--- a/help/opers/rehash
+++ b/help/opers/rehash
@@ -17,11 +17,11 @@ ircd.conf file.
   TRESVS   - Clears temporary nick and channel resvs
   TXLINES  - Clears temporary X Lines
 
-- Requires Oper Priv: H
+- Requires Oper Priv: oper:rehash
 
 REHASH [option] irc.server
 
 Rehashes [option], or the config file if none given, on irc.server if
 irc.server accepts remote rehashes.
 
-- Requires Oper Priv: HB
+- Requires Oper Privs: oper:rehash, oper:remoteban

--- a/help/opers/restart
+++ b/help/opers/restart
@@ -1,5 +1,7 @@
-RESTART server.name
+RESTART server.name [server.name]
 
-Restarts the IRC server.
+Restarts the IRC server. If a second server name
+is provided, remotely restart that server. In this
+case, both server names must match.
 
-- Requires Oper Priv: D
+- Requires Oper Priv: oper:admin

--- a/help/opers/squit
+++ b/help/opers/squit
@@ -1,4 +1,4 @@
 SQUIT <server> [reason]
 
 Splits <server> away from your side of the net with [reason].
-- Requires Oper Priv: R for servers not connected to you
+- Requires Oper Priv: oper:remote for servers not connected to you

--- a/help/opers/trace
+++ b/help/opers/trace
@@ -3,11 +3,11 @@ TRACE [server | nick] [location]
 With no argument, TRACE gives a list of all clients connected
 to the local server, both users and operators.
 
-With one argument which is a server, TRACE displays the path 
+With one argument which is a server, TRACE displays the path
 to the specified server, and all servers, opers and -i users
 on that server.
 
-Nonopers can only see themselves, opers and servers in the
+Nonopers can only see themselves, opers, and servers in the
 first two forms.
 
 With one argument which is a client, TRACE displays the

--- a/help/opers/umode
+++ b/help/opers/umode
@@ -1,12 +1,15 @@
 MODE <nick> <+|-><modes>
 
-Usermodes: (* designates that the umode is oper only)
+User modes: (* designates that the umode is oper only)
+            (? designates that the umode is provided by an extension
+	     and may not be present on this server)
 
      USERMODE     DESCRIPTION
 -----------------------------------------------------------------
          +i     - Designates this client 'invisible'.
          +g     - "caller id" mode only allow accept clients to message you
          +w     - Can see oper and server wallops.
+       ? +h     - Has a cloaked host. May be +x depending on cloaking module
          +o     - Designates this client is an IRC Operator.
                   Use the /oper command to attain this.
        * +a     - Is marked as a server admin in whois.

--- a/help/opers/undline
+++ b/help/opers/undline
@@ -2,4 +2,4 @@ UNDLINE <ip>
 
 Will attempt to undline the given <ip>
 
-- Requires Oper Priv: U
+- Requires Oper Priv: oper:unkline

--- a/help/opers/unkline
+++ b/help/opers/unkline
@@ -7,4 +7,4 @@ UNKLINE <user@host> ON irc.server will unkline
 the user on irc.server if irc.server accepts
 remote unklines.
 
-- Requires Oper Priv: U
+- Requires Oper Priv: oper:unkline

--- a/help/opers/unxline
+++ b/help/opers/unxline
@@ -7,4 +7,4 @@ UNXLINE <gecos> ON <server>
 
 Will attempt to unxline the given <gecos> on <server>.
 
-- Requires Oper Priv: X
+- Requires Oper Priv: oper:xline

--- a/help/opers/wallops
+++ b/help/opers/wallops
@@ -5,4 +5,4 @@ who are umode +w (including non-opers).
 
 Server sent WALLOPS go to all opers who are umode +w.
 
-- Requires Oper Priv: M
+- Requires Oper Priv: oper:operwall

--- a/help/opers/xline
+++ b/help/opers/xline
@@ -1,7 +1,7 @@
 XLINE [time] <gecos> :<reason>
 
 Bans by gecos (aka 'real name') field.  If [time] is not specified
-this is added to the database, otherwise is temporary for [time] 
+this is added to the database, otherwise is temporary for [time]
 minutes.
 
 Eg. /quote xline eggdrop?bot :no bots
@@ -12,12 +12,12 @@ The <gecos> field contains certain special characters:
   @ - Match any letter [A-Za-z]
   # - Match any digit [0-9]
 
-To use a literal one of these characters, escape it with '\'.  A 
+To use a literal one of these characters, escape it with '\'.  A
 literal '\' character must also be escaped.  You may also insert \s
 which will be converted into a space.
 
 If the <gecos> field is purely numeric (ie "123") then the time
-field must be specified.  "0" must be used to denote a permanent 
+field must be specified.  "0" must be used to denote a permanent
 numeric XLINE.
 
 XLINE [time] <gecos> ON <server> :<reason>
@@ -25,4 +25,4 @@ XLINE [time] <gecos> ON <server> :<reason>
 Will attempt to set the XLINE on <server> if <server> accepts
 remote xlines.
 
-- Requires Oper Priv: X
+- Requires Oper Priv: oper:xline

--- a/help/users/umode
+++ b/help/users/umode
@@ -1,12 +1,14 @@
 MODE <nick> <+|-><modes>
 
-Usermodes:
+User modes: (? designates that the umode is provided by an extension
+             and may not be present on this server)
 
      USERMODE     DESCRIPTION
 -----------------------------------------------------------------
          +o     - Designates this client is an IRC Operator.
                   Use the /oper command to attain this.
          +i     - Designates this client 'invisible'.
+       ? +h     - Has a cloaked host. May be +x depending on cloaking module
          +g     - "caller id" mode only allow accept clients to message you
          +w     - Can see oper wallops.
          +D     - Deaf - ignores all channel messages.


### PR DESCRIPTION
What is done here:
1. All the outdated configuration flag information has been removed and replaced with the more current information.
2. Spellchecking has been done on all helpfiles and the actual errors have been fixed. (IRC terms such as PRIVMSG are "correctly" flagged as misspelled)
