### PR TITLE
Inform opers about invalid hostnames

### DIFF
--- a/src/s_user.c
+++ b/src/s_user.c
@@ -301,6 +301,8 @@ register_local_user(struct Client *client_p, struct Client *source_p, const char
 	if(!valid_hostname(source_p->host))
 	{
 		sendto_one_notice(source_p, ":*** Notice -- You have an illegal character in your hostname");
+		sendto_realops_snomask(SNO_REJ, L_ALL, "Invalid hostname: %s (of user %s)",
+			source_p->host, source_p->name);
 
 		rb_strlcpy(source_p->host, source_p->sockhost, sizeof(source_p->host));
  	}


### PR DESCRIPTION
When the username is invalid, it is shown to opers and to the blocked user so that they know how to fix it. The same should be done here.
