### PR TITLE
example configs: remove AHBL

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -397,23 +397,11 @@ serverhide {
  *
  * Consult your blacklist provider for the meaning of these parameters; they
  * are usually used to denote different ban types.
- *
- * Note: AHBL (the providers of the below *.ahbl.org BLs) request that they be
- * contacted, via email, at admins@2mbit.com before using these BLs.
- * See <http://www.ahbl.org/services.php> for more information.
  */
 blacklist {
 	host = "rbl.efnetrbl.org";
 	type = ipv4;
 	reject_reason = "${nick}, your IP (${ip}) is listed in EFnet's RBL. For assistance, see http://efnetrbl.org/?i=${ip}";
-
-#	host = "ircbl.ahbl.org";
-#	type = ipv4;
-#	reject_reason = "${nick}, your IP (${ip}) is listed in ${dnsbl-host} for having an open proxy. In order to protect ${network-name} from abuse, we are not allowing connections with open proxies to connect.";
-#
-#	host = "tor.ahbl.org";
-#	type = ipv4;
-#	reject_reason = "${nick}, your IP (${ip}) is listed as a TOR exit node. In order to protect ${network-name} from tor-based abuse, we are not allowing TOR exit nodes to connect to our network.";
 #
 	/* Example of a blacklist that supports both IPv4 and IPv6 and using matches */
 #	host = "foobl.blacklist.invalid";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -851,23 +851,11 @@ serverhide {
  * 
  * Consult your blacklist provider for the meaning of these parameters; they
  * are usually used to denote different ban types.
- *
- * Note: AHBL (the providers of the below *.ahbl.org BLs) request that they be
- * contacted, via email, at admins@2mbit.com before using these BLs.
- * See <http://www.ahbl.org/services.php> for more information.
  */
 blacklist {
 	host = "rbl.efnetrbl.org";
 	type = ipv4;
 	reject_reason = "${nick}, your IP (${ip}) is listed in EFnet's RBL. For assistance, see http://efnetrbl.org/?i=${ip}";
-
-#	host = "ircbl.ahbl.org";
-#	type = ipv4;
-#	reject_reason = "${nick}, your IP (${ip}) is listed in ${dnsbl-host} for having an open proxy. In order to protect ${network-name} from abuse, we are not allowing connections with open proxies to connect.";
-#
-#	host = "tor.ahbl.org";
-#	type = ipv4;
-#	reject_reason = "${nick}, your IP (${ip}) is listed as a TOR exit node. In order to protect ${network-name} from tor-based abuse, we are not allowing TOR exit nodes to connect to our network.";
 #
 	/* Example of a blacklist that supports both IPv4 and IPv6 and using matches */
 #	host = "foobl.blacklist.invalid";


### PR DESCRIPTION
AHBL has been shut down recently, and all its DNSBLs just point to dummy
nameservers. (See http://ahbl.org/content/changes-ahbl for details.)
