### PR TITLE
strip_colour: Strip '\x0F' (^O, formatting off)

### DIFF
--- a/include/inline/stringops.h
+++ b/include/inline/stringops.h
@@ -56,6 +56,7 @@ strip_colour(char *string)
 		case 4:
 		case 6:
 		case 7:
+		case 15:
 		case 22:
 		case 23:
 		case 27:


### PR DESCRIPTION
Reported by @ssbr on freenode:

chmode `+c` doesn't strip `^O`, which turns off all previous formatting. This can cause clients that internally use mIRC formatting to render messages weirdly, e.g. [highlighted messages in HexChat](https://i.imgur.com/eDX8Aif.png).
