### PR TITLE
Fix buffer overflow in introduce_client and burst_TS6

### DIFF
--- a/src/s_serv.c
+++ b/src/s_serv.c
@@ -555,7 +555,7 @@ burst_modes_TS6(struct Client *client_p, struct Channel *chptr,
 static void
 burst_TS6(struct Client *client_p)
 {
-	static char ubuf[12];
+	char ubuf[BUFSIZE];
 	struct Client *target_p;
 	struct Channel *chptr;
 	struct membership *msptr;

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -592,7 +592,7 @@ register_local_user(struct Client *client_p, struct Client *source_p, const char
 int
 introduce_client(struct Client *client_p, struct Client *source_p, struct User *user, const char *nick, int use_euid)
 {
-	static char ubuf[12];
+	char ubuf[BUFSIZE];
 	struct Client *identifyservice_p;
 	char *p;
 	hook_data_umode_changed hdata;


### PR DESCRIPTION
If the client being introduced has more than 10 user modes send_umode()
will overflow ubuf
