### PR TITLE
example configs: change ssl_cert to etc/ssl.pem

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -62,7 +62,7 @@ serverinfo {
 	ssl_private_key = "etc/ssl.key";
 
 	/* ssl_cert: certificate for our ssl server */
-	ssl_cert = "etc/ssl.cert";
+	ssl_cert = "etc/ssl.pem";
 
 	/* ssl_dh_params: DH parameters, generate with openssl dhparam -out dh.pem 1024 */
 	ssl_dh_params = "etc/dh.pem";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -143,7 +143,7 @@ serverinfo {
 	ssl_private_key = "etc/ssl.key";
 
 	/* ssl_cert: certificate for our ssl server */
-	ssl_cert = "etc/ssl.cert";
+	ssl_cert = "etc/ssl.pem";
 
 	/* ssl_dh_params: DH parameters, generate with openssl dhparam -out dh.pem 1024 */
 	ssl_dh_params = "etc/dh.pem";


### PR DESCRIPTION
The genssl script writes to etc/ssl.pem by default.
