### PR TITLE
Remove incorrect comment regarding location of functions in src/modules.c

### DIFF
--- a/src/modules.c
+++ b/src/modules.c
@@ -40,18 +40,6 @@
 #include "match.h"
 
 
-
-/* -TimeMr14C:
- * I have moved the dl* function definitions and
- * the two functions (load_a_module / unload_a_module) to the
- * file dynlink.c
- * And also made the necessary changes to those functions
- * to comply with shl_load and friends.
- * In this file, to keep consistency with the makefile,
- * I added the ability to load *.sl files, too.
- * 27/02/2002
- */
-
 #ifndef STATIC_MODULES
 
 struct module **modlist = NULL;


### PR DESCRIPTION
Comment is from 2002, and states the load/unload_a_module and dl\* were moved to dynlink.c . This is both confusing, and incorrect.
