### PR TITLE
autoconf: Quote AC_LANG_PROGRAM when used within AC_*_IFELSE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,11 +296,11 @@ if test "$cf_enable_openssl" != no; then
 	dnl Check OpenSSL version (must be 0.9.6 or above!)
 	AC_MSG_CHECKING(for OpenSSL 0.9.6 or above)
 	AC_RUN_IFELSE(
-		AC_LANG_PROGRAM(
+		[AC_LANG_PROGRAM(
 	    	[#include <openssl/opensslv.h>
 		#include <stdlib.h>],
 		[[if ( OPENSSL_VERSION_NUMBER >= 0x00906000)
-		exit(0); else exit(1);]]),
+		exit(0); else exit(1);]])],
 	cf_openssl_version_ok=yes,
 	cf_openssl_version_ok=no,
 	cf_openssl_version_ok=no)
@@ -590,7 +590,7 @@ AC_DEFINE_UNQUOTED(NICKLEN, (${NICKLEN}+1), [Nickname length])
 hold_ldflags=$LDFLAGS
 AC_MSG_CHECKING(for the ld -rpath flag)
 LDFLAGS="${LDFLAGS} -Wl,-rpath=${libdir}"
-AC_LINK_IFELSE(AC_LANG_PROGRAM([],[int i;]), found=yes, found=no)
+AC_LINK_IFELSE([AC_LANG_PROGRAM([],[int i;])], found=yes, found=no)
 LDFLAGS=$hold_ldflags
 AC_MSG_RESULT($found)
 if test "$found" = yes; then

--- a/libratbox/configure.ac
+++ b/libratbox/configure.ac
@@ -307,11 +307,11 @@ if test "$cf_enable_openssl" != no; then
 	dnl Check OpenSSL version (must be 0.9.7 or above!)
 	AC_MSG_CHECKING(for OpenSSL 0.9.7 or above)
 	AC_RUN_IFELSE(
-		AC_LANG_PROGRAM(
+		[AC_LANG_PROGRAM(
 	    	[#include <openssl/opensslv.h>
 		#include <stdlib.h>],
 		[[if (OPENSSL_VERSION_NUMBER >= 0x00907000)
-		exit(0); else exit(1);]]),
+		exit(0); else exit(1);]])],
 	cf_enable_openssl=yes,
 	cf_enable_openssl=no,
 	cf_enable_openssl=no)


### PR DESCRIPTION
AC_LANG_PROGRAM needs to be quoted when used within AC_*_IFELSE:
https://lists.gnu.org/archive/html/bug-autoconf/2011-04/msg00017.html

This fixes the following warnings:

$ autoreconf
configure.ac:298: warning: AC_LANG_CONFTEST: no AC_LANG_SOURCE call detected in body
../../lib/autoconf/lang.m4:193: AC_LANG_CONFTEST is expanded from...
../../lib/autoconf/general.m4:2729: _AC_RUN_IFELSE is expanded from...
../../lib/m4sugar/m4sh.m4:639: AS_IF is expanded from...
../../lib/autoconf/general.m4:2748: AC_RUN_IFELSE is expanded from...
configure.ac:298: the top level
configure.ac:593: warning: AC_LANG_CONFTEST: no AC_LANG_SOURCE call detected in body
../../lib/autoconf/lang.m4:193: AC_LANG_CONFTEST is expanded from...
../../lib/autoconf/general.m4:2661: _AC_LINK_IFELSE is expanded from...
../../lib/autoconf/general.m4:2678: AC_LINK_IFELSE is expanded from...
configure.ac:593: the top level
...
configure.ac:309: warning: AC_LANG_CONFTEST: no AC_LANG_SOURCE call detected in body
../../lib/autoconf/lang.m4:193: AC_LANG_CONFTEST is expanded from...
../../lib/autoconf/general.m4:2729: _AC_RUN_IFELSE is expanded from...
../../lib/m4sugar/m4sh.m4:639: AS_IF is expanded from...
../../lib/autoconf/general.m4:2748: AC_RUN_IFELSE is expanded from...
configure.ac:309: the top level
...