### PR TITLE
ircd: chmode: Avoid referencing beyond the end of the flags_list array in set_channel_mode

### DIFF
--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -1545,8 +1545,9 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 				  source_p->name, source_p->username,
 				  source_p->host, chptr->chname);
 
-	for(j = 0, flags = flags_list[0]; j < 3; j++, flags = flags_list[j])
+	for(j = 0; j < 3; j++)
 	{
+		flags = flags_list[j];
 		cur_len = mlen;
 		mbuf = modebuf + mlen;
 		pbuf = parabuf;


### PR DESCRIPTION
We're setting `flags` to `flags_list[3]` at the end of the loop, but the
array only has 3 elements. Unless the compiler optimises this away
(because `flags` will not be used again) we're accessing memory beyond
the end of the array.

With gcc-4.9:
```
chmode.c: In function 'set_channel_mode':
chmode.c:1548:54: warning: iteration 2u invokes undefined behavior [-Waggressive-loop-optimizations]
  for(j = 0, flags = flags_list[0]; j < 3; j++, flags = flags_list[j])
                                                      ^
chmode.c:1548:2: note: containing loop
  for(j = 0, flags = flags_list[0]; j < 3; j++, flags = flags_list[j])
```

Explicitly set `flags = flags_list[j]` at the start of each loop
iteration, which will avoid referencing off the end of the array.