### PR TITLE
libratbox: define UINT16_MAX

### DIFF
--- a/libratbox/include/ratbox_lib.h
+++ b/libratbox/include/ratbox_lib.h
@@ -171,6 +171,10 @@ char *rb_strerror(int error);
 #define INT16SZ 2
 #endif
 
+#ifndef UINT16_MAX
+#define UINT16_MAX (65535U)
+#endif
+
 
 typedef void log_cb(const char *buffer);
 typedef void restart_cb(const char *buffer);


### PR DESCRIPTION
UINT16_MAX may not be defined on some ancient hosts (FreeBSD 4.8)

It's used by libratbox/src/tools.c