### PR TITLE
authd: fix link failure in random_socket

### DIFF
--- a/authd/res.c
+++ b/authd/res.c
@@ -62,9 +62,9 @@ static PF res_readreply;
 #define ANSWER_FIXED_SIZE (TYPE_SIZE + CLASS_SIZE + TTL_SIZE + RDLENGTH_SIZE)
 
 #ifdef RB_IPV6
-extern struct in6_addr ipv6_addr;
+struct in6_addr ipv6_addr;
 #endif
-extern struct in_addr ipv4_addr;
+struct in_addr ipv4_addr;
 
 struct reslist
 {


### PR DESCRIPTION
The random_socket function isn't used, and the code can only be
compiled if the function is optimised away (because it's static
and unused) otherwise it will fail to link when "ipv4_addr" and
"ipv6_addr" are not found.

Fix this by modifying ipv4_addr and ipv6_addr so that they're not
external variables.