### PR TITLE
ircd: Handle start_ssld_connect failure

### DIFF
--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1157,6 +1157,11 @@ serv_connect_ssl_callback(rb_fde_t *F, int status, void *data)
 	add_to_cli_connid_hash(client_p);
 
 	client_p->localClient->ssl_ctl = start_ssld_connect(F, xF[1], rb_get_fd(xF[0]));
+	if(!client_p->localClient->ssl_ctl)
+	{
+		serv_connect_callback(client_p->localClient->F, RB_ERROR, data);
+		return;
+	}
 	SetSSL(client_p);
 	serv_connect_callback(client_p->localClient->F, RB_OK, client_p);
 }


### PR DESCRIPTION
It's possible for start_ssld_connect to fail and return NULL,
handle this by reporting an error connecting.

(There is already a similar check when start_ssld_accept is called)