### PR TITLE
ircd: Handle which_ssld failure

### DIFF
--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -1157,6 +1157,11 @@ serv_connect_ssl_callback(rb_fde_t *F, int status, void *data)
 	add_to_cli_connid_hash(client_p);
 
 	client_p->localClient->ssl_ctl = start_ssld_connect(F, xF[1], rb_get_fd(xF[0]));
+	if(!client_p->localClient->ssl_ctl)
+	{
+		serv_connect_callback(client_p->localClient->F, RB_ERROR, data);
+		return;
+	}
 	SetSSL(client_p);
 	serv_connect_callback(client_p->localClient->F, RB_OK, client_p);
 }

--- a/ircd/sslproc.c
+++ b/ircd/sslproc.c
@@ -809,6 +809,7 @@ start_zlib_session(void *data)
 		sendto_realops_snomask(SNO_GENERAL, L_ALL, "Error creating zlib socketpair - %s", strerror(errno));
 		ilog(L_MAIN, "Error creating zlib socketpairs - %s", strerror(errno));
 		exit_client(server, server, server, "Error creating zlib socketpair");
+		rb_free(buf);
 		return;
 	}
 

--- a/ircd/sslproc.c
+++ b/ircd/sslproc.c
@@ -703,6 +703,8 @@ start_ssld_accept(rb_fde_t * sslF, rb_fde_t * plainF, uint32_t id)
 	buf[0] = 'A';
 	uint32_to_buf(&buf[1], id);
 	ctl = which_ssld();
+	if(!ctl)
+		return NULL;
 	ctl->cli_count++;
 	ssl_cmd_write_queue(ctl, F, 2, buf, sizeof(buf));
 	return ctl;
@@ -721,6 +723,8 @@ start_ssld_connect(rb_fde_t * sslF, rb_fde_t * plainF, uint32_t id)
 	uint32_to_buf(&buf[1], id);
 
 	ctl = which_ssld();
+	if(!ctl)
+		return NULL;
 	ctl->cli_count++;
 	ssl_cmd_write_queue(ctl, F, 2, buf, sizeof(buf));
 	return ctl;
@@ -832,6 +836,12 @@ start_zlib_session(void *data)
 	add_to_cli_connid_hash(server);
 
 	server->localClient->z_ctl = which_ssld();
+	if(!server->localClient->z_ctl)
+	{
+		exit_client(server, server, server, "Error finding available ssld");
+		rb_free(buf);
+		return;
+	}
 	server->localClient->z_ctl->cli_count++;
 	ssl_cmd_write_queue(server->localClient->z_ctl, F, 2, buf, len);
 	rb_free(buf);


### PR DESCRIPTION
It's possible for which_ssld to fail and return NULL, handle this in
start_ssld_connect and start_ssld_accept by returning NULL. The NULL
return value is already handled in all calls to start_ssld_accept,
so handle this for start_ssld_connect by reporting an error connecting.

Handle it in start_zlib_session by exiting the client.