### PR TITLE
add missing files to the clean target

### DIFF
--- a/libratbox/Makefile.in
+++ b/libratbox/Makefile.in
@@ -100,7 +100,7 @@ am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
  configure.lineno config.status.lineno
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/include/libratbox_config.h
-CONFIG_CLEAN_FILES = libratbox.pc
+CONFIG_CLEAN_FILES = libratbox.pc include/librb-config.h
 CONFIG_CLEAN_VPATH_FILES =
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)

--- a/libratbox/src/Makefile.in
+++ b/libratbox/src/Makefile.in
@@ -99,7 +99,7 @@ am__configure_deps = $(am__aclocal_m4_deps) $(CONFIGURE_DEPENDENCIES) \
 DIST_COMMON = $(srcdir)/Makefile.am $(am__DIST_COMMON)
 mkinstalldirs = $(install_sh) -d
 CONFIG_HEADER = $(top_builddir)/include/libratbox_config.h
-CONFIG_CLEAN_FILES =
+CONFIG_CLEAN_FILES = version.c version.c.last
 CONFIG_CLEAN_VPATH_FILES =
 am__vpath_adj_setup = srcdirstrip=`echo "$(srcdir)" | sed 's|.|.|g'`;
 am__vpath_adj = case $$p in \


### PR DESCRIPTION
without those, `make; make clean` is not idempotent.

i have found this patch lying around in my debian patch series, and it seems to still be relevant.