### PR TITLE
make build reproducible

### DIFF
--- a/include/ircd.h
+++ b/include/ircd.h
@@ -61,7 +61,6 @@ extern struct SetOptions GlobalSetOptions;	/* defined in ircd.c */
 
 extern const char *creation;
 extern const char *generation;
-extern const char *platform;
 extern const char *infotext[];
 extern const char *serno;
 extern const char *ircd_version;

--- a/ircd/version.c.SH
+++ b/ircd/version.c.SH
@@ -17,13 +17,15 @@ fi
 
 generation=`expr $generation + 1`
 
-uname=`uname -a`
-
-creation=`LC_ALL=C date | \
+if test "$EXTERNAL_BUILD_TIMESTAMP" = ''; then
+    creation=`LC_ALL=C date | \
 awk '{if (NF == 6) \
          { print $1 " "  $2 " " $3 " "  $6 " at " $4 " " $5 } \
 else \
          { print $1 " "  $2 " " $3 " " $7 " at " $4 " " $5 " " $6 }}'`
+else
+    creation="$EXTERNAL_BUILD_TIMESTAMP"
+fi
 
 $spitshell >version.c <<!SUB!THIS!
 /*
@@ -54,7 +56,6 @@ $spitshell >version.c <<!SUB!THIS!
 
 const char *generation = "$generation";
 const char *creation = "$creation";
-const char *platform = "$uname";
 const char *ircd_version = PATCHLEVEL;
 const char *serno = SERNO;
 

--- a/libratbox/src/version.c.SH
+++ b/libratbox/src/version.c.SH
@@ -17,14 +17,6 @@ fi
 
 generation=`expr $generation + 1`
 
-uname=`uname -a`
-
-creation=`date | \
-awk '{if (NF == 6) \
-         { print $1 " "  $2 " " $3 " "  $6 " at " $4 " " $5 } \
-else \
-         { print $1 " "  $2 " " $3 " " $7 " at " $4 " " $5 " " $6 }}'`
-
 $spitshell >version.c <<!SUB!THIS!
 /*
  *   libratbox: a library used by ircd-ratbox and other things
@@ -55,9 +47,7 @@ $spitshell >version.c <<!SUB!THIS!
 #include "../include/serno.h"
 
 const char *libratbox_generation = "$generation";
-const char *libratbox_platform = "$uname";
 const char *libratbox_serno = SERIALNUM;
-const char *libratbox_creation = "$creation";
 
 const char *libratbox_infotext[] =
 {


### PR DESCRIPTION
we do this by removing the uname usage everywhere: it is not actually
used at runtime at all.

we keep the timestamp, because it is actually used in user_welcome()
but allow it to be overriden.

ideally, that timestamp would be completely removed, but I am not sure
what to put in its place, or if it would break some mysterious RFC (or
client!) if we remove that announcement.

closes #148.