### PR TITLE
parse: get rid of report_messages

### DIFF
--- a/include/parse.h
+++ b/include/parse.h
@@ -42,5 +42,6 @@ extern void mod_del_cmd(struct Message *msg);
 extern char *reconstruct_parv(int parc, const char *parv[]);
 
 extern struct Dictionary *alias_dict;
+extern struct Dictionary *cmd_dict;
 
 #endif /* INCLUDED_parse_h_h */

--- a/include/parse.h
+++ b/include/parse.h
@@ -39,7 +39,6 @@ extern void handle_encap(struct MsgBuf *, struct Client *, struct Client *,
 extern void clear_hash_parse(void);
 extern void mod_add_cmd(struct Message *msg);
 extern void mod_del_cmd(struct Message *msg);
-extern void report_messages(struct Client *);
 extern char *reconstruct_parv(int parc, const char *parv[]);
 
 extern struct Dictionary *alias_dict;

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -338,38 +338,6 @@ mod_del_cmd(struct Message *msg)
 	irc_dictionary_delete(cmd_dict, msg->cmd);
 }
 
-/*
- * report_messages
- *
- * inputs	- pointer to client to report to
- * output	- NONE
- * side effects	- NONE
- */
-void
-report_messages(struct Client *source_p)
-{
-	struct DictionaryIter iter;
-	struct Message *msg;
-	struct alias_entry *amsg;
-
-	DICTIONARY_FOREACH(msg, &iter, cmd_dict)
-	{
-		s_assert(msg->cmd != NULL);
-		sendto_one_numeric(source_p, RPL_STATSCOMMANDS,
-				   form_str(RPL_STATSCOMMANDS),
-				   msg->cmd, msg->count,
-				   msg->bytes, msg->rcount);
-	}
-
-	DICTIONARY_FOREACH(amsg, &iter, alias_dict)
-	{
-		s_assert(amsg->name != NULL);
-		sendto_one_numeric(source_p, RPL_STATSCOMMANDS,
-				   form_str(RPL_STATSCOMMANDS),
-				   amsg->name, amsg->hits, 0L, 0);
-	}
-}
-
 /* cancel_clients()
  *
  * inputs	- client who sent us the message, client with fake

--- a/ircd/parse.c
+++ b/ircd/parse.c
@@ -44,7 +44,7 @@
 #include "packet.h"
 #include "s_assert.h"
 
-static struct Dictionary *cmd_dict = NULL;
+struct Dictionary *cmd_dict = NULL;
 struct Dictionary *alias_dict = NULL;
 
 /* parv[0] is not used, and parv[LAST] == NULL */

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -722,7 +722,26 @@ stats_klines(struct Client *source_p)
 static void
 stats_messages(struct Client *source_p)
 {
-	report_messages(source_p);
+	struct DictionaryIter iter;
+	struct Message *msg;
+	struct alias_entry *amsg;
+
+	DICTIONARY_FOREACH(msg, &iter, cmd_dict)
+	{
+		s_assert(msg->cmd != NULL);
+		sendto_one_numeric(source_p, RPL_STATSCOMMANDS,
+				   form_str(RPL_STATSCOMMANDS),
+				   msg->cmd, msg->count,
+				   msg->bytes, msg->rcount);
+	}
+
+	DICTIONARY_FOREACH(amsg, &iter, alias_dict)
+	{
+		s_assert(amsg->name != NULL);
+		sendto_one_numeric(source_p, RPL_STATSCOMMANDS,
+				   form_str(RPL_STATSCOMMANDS),
+				   amsg->name, amsg->hits, 0L, 0);
+	}
 }
 
 static void
@@ -1771,4 +1790,3 @@ stats_p_spy (struct Client *source_p)
 
 	call_hook(doing_stats_p_hook, &data);
 }
-


### PR DESCRIPTION
It is a function with a single usage, that is used only for one specific stats command (which is used only on one line).