### PR TITLE
Remove some leftover ircd-ratbox references.

### DIFF
--- a/bandb/bandb.c
+++ b/bandb/bandb.c
@@ -302,10 +302,9 @@ main(int argc, char *argv[])
 	if(bandb_helper == NULL)
 	{
 		fprintf(stderr,
-			"This is ircd-ratbox bandb.  You aren't supposed to run me directly. Maybe you want bantool?\n");
+			"This is the charybdis bandb for internal ircd use.\n");
 		fprintf(stderr,
-			"However I will print my Id tag $Id: bandb.c 26094 2008-09-19 15:33:46Z androsyn $\n");
-		fprintf(stderr, "Have a nice day\n");
+			"You aren't supposed to run me directly (did you want bantool?). Exiting.\n");
 		exit(1);
 	}
 	rsdb_init(db_error_cb);

--- a/ssld/ssld.c
+++ b/ssld/ssld.c
@@ -1206,10 +1206,9 @@ main(int argc, char **argv)
 	if(s_ctlfd == NULL || s_pipe == NULL || s_pid == NULL)
 	{
 		fprintf(stderr,
-			"This is ircd-ratbox ssld.  You know you aren't supposed to run me directly?\n");
+			"This is the charybdis ssld for internal ircd use.\n");
 		fprintf(stderr,
-			"You get an Id tag for this: $Id$\n");
-		fprintf(stderr, "Have a nice life\n");
+			"You aren't supposed to run me directly. Exiting.\n");
 		exit(1);
 	}
 


### PR DESCRIPTION
These are in ssld and bandb. Also, the new text is more grammatically correct and removes the old CVS ID's.