### PR TITLE
core/m_error: Be consistent in strncmp usage

### DIFF
--- a/modules/core/m_error.c
+++ b/modules/core/m_error.c
@@ -68,7 +68,7 @@ is_safe_error(const char *message)
 	if (!strncmp(message, "Terminated by ", 14))
 		return 1;
 
-	if (!ircncmp(message, "Closing Link", 12))
+	if (!strncmp(message, "Closing Link", 12))
 		return 0;
 	if (strchr(message, '['))
 		return 0;


### PR DESCRIPTION
I see absolutely no reason why ircncmp was used here.