### PR TITLE
limit failed SASL authentication attempts

### DIFF
--- a/include/client.h
+++ b/include/client.h
@@ -285,6 +285,7 @@ struct LocalUser
 	char sasl_agent[IDLEN];
 	unsigned char sasl_out;
 	unsigned char sasl_complete;
+	unsigned short sasl_messages;
 };
 
 struct AuthClient

--- a/include/client.h
+++ b/include/client.h
@@ -285,7 +285,10 @@ struct LocalUser
 	char sasl_agent[IDLEN];
 	unsigned char sasl_out;
 	unsigned char sasl_complete;
-	unsigned short sasl_messages;
+
+	unsigned int sasl_messages;
+	unsigned int sasl_failures;
+	time_t sasl_next_retry;
 };
 
 struct AuthClient

--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -35,6 +35,7 @@
 #include "msg.h"
 #include "modules.h"
 #include "numeric.h"
+#include "reject.h"
 #include "s_serv.h"
 #include "s_stats.h"
 #include "string.h"
@@ -223,17 +224,30 @@ me_sasl(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		rb_strlcpy(target_p->localClient->sasl_agent, parv[1], IDLEN);
 
 	if(*parv[3] == 'C')
+	{
 		sendto_one(target_p, "AUTHENTICATE %s", parv[4]);
+		target_p->localClient->sasl_messages++;
+	}
 	else if(*parv[3] == 'D')
 	{
-		if(*parv[4] == 'F')
+		if(*parv[4] == 'F') {
 			sendto_one(target_p, form_str(ERR_SASLFAIL), me.name, EmptyString(target_p->name) ? "*" : target_p->name);
+			if (target_p->localClient->sasl_messages > 0)
+			{
+				if (throttle_add((struct sockaddr*)&target_p->localClient->ip))
+				{
+					exit_client(target_p, target_p, &me, "Too many failed authentication attempts");
+					return;
+				}
+			}
+		}
 		else if(*parv[4] == 'S') {
 			sendto_one(target_p, form_str(RPL_SASLSUCCESS), me.name, EmptyString(target_p->name) ? "*" : target_p->name);
 			target_p->localClient->sasl_complete = 1;
 			ServerStats.is_ssuc++;
 		}
 		*target_p->localClient->sasl_agent = '\0'; /* Blank the stored agent so someone else can answer */
+		target_p->localClient->sasl_messages = 0;
 	}
 	else if(*parv[3] == 'M')
 		sendto_one(target_p, form_str(RPL_SASLMECHS), me.name, EmptyString(target_p->name) ? "*" : target_p->name, parv[4]);

--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -230,18 +230,20 @@ me_sasl(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	}
 	else if(*parv[3] == 'D')
 	{
-		if(*parv[4] == 'F') {
+		if(*parv[4] == 'F')
+		{
 			sendto_one(target_p, form_str(ERR_SASLFAIL), me.name, EmptyString(target_p->name) ? "*" : target_p->name);
-			if (target_p->localClient->sasl_messages > 0)
+			if(target_p->localClient->sasl_messages > 0)
 			{
-				if (throttle_add((struct sockaddr*)&target_p->localClient->ip))
+				if(throttle_add((struct sockaddr*)&target_p->localClient->ip))
 				{
 					exit_client(target_p, target_p, &me, "Too many failed authentication attempts");
 					return;
 				}
 			}
 		}
-		else if(*parv[4] == 'S') {
+		else if(*parv[4] == 'S')
+		{
 			sendto_one(target_p, form_str(RPL_SASLSUCCESS), me.name, EmptyString(target_p->name) ? "*" : target_p->name);
 			target_p->localClient->sasl_complete = 1;
 			ServerStats.is_ssuc++;


### PR DESCRIPTION
This disconnects the user and adds a temporary reject if the same connection fails authentication too many times. (In v3, it uses the same counter as the regular reconnection throttle – one failed auth counts as one reconnection.)

"Unknown mechanism" failures are not affected by this.

Todo:

 - <del>should registered clients (SASL Reauth) be exempted from this?</del> added throttling for Reauth
 - should there be a separate failed auth attempt limit ([as in v1](https://github.com/charybdis-ircd/charybdis/compare/master...grawity:sasl-fail-throttle-v1))?