### PR TITLE
fix error handling in gnutls certfp support

### DIFF
--- a/libratbox/src/gnutls.c
+++ b/libratbox/src/gnutls.c
@@ -608,18 +608,17 @@ rb_get_ssl_certfp(rb_fde_t *F, uint8_t certfp[RB_SSL_CERTFP_LEN], int method)
 	if (gnutls_certificate_type_get(SSL_P(F)) != GNUTLS_CRT_X509)
 		return 0;
 
-	if (gnutls_x509_crt_init(&cert) < 0)
-		return 0;
-
 	cert_list_size = 0;
 	cert_list = gnutls_certificate_get_peers(SSL_P(F), &cert_list_size);
-	if (cert_list == NULL)
+	if (cert_list_size <= 0)
 	{
-		gnutls_x509_crt_deinit(cert);
 		return 0;
 	}
 
-	if (gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER) < 0)
+	if (gnutls_x509_crt_init(&cert) != GNUTLS_E_SUCCESS)
+		return 0;
+
+	if (gnutls_x509_crt_import(cert, &cert_list[0], GNUTLS_X509_FMT_DER) != GNUTLS_E_SUCCESS)
 	{
 		gnutls_x509_crt_deinit(cert);
 		return 0;
@@ -643,7 +642,7 @@ rb_get_ssl_certfp(rb_fde_t *F, uint8_t certfp[RB_SSL_CERTFP_LEN], int method)
 		return 0;
 	}
 
-	if (gnutls_x509_crt_get_fingerprint(cert, algo, digest, &digest_size) < 0)
+	if (gnutls_x509_crt_get_fingerprint(cert, algo, digest, &digest_size) != 0)
 	{
 		gnutls_x509_crt_deinit(cert);
 		return 0;


### PR DESCRIPTION
GNUTLS servers running Charybdis 3.4 or 3.5 can't authentify CertFP-enable accounts correctly with nickserv, while Charybdis 3.3 can do it fine. There seems to be issues with the way it is implemented in GnuTLS, as OpenSSL and 3.5 don't seem to be affected.

4.0rc2 on the testnet is not affected, but I do not know which backend it is using, so it's possible the 4.x branch is also affected.

It seems the problem can be traced back to improper error handling in the GNUTLS CertFP code, which this patch fixes in my tests (and in production).
