### PR TITLE
m_grant.c - fixed remote grant support

### DIFF
--- a/modules/m_grant.c
+++ b/modules/m_grant.c
@@ -107,7 +107,7 @@ void grant_revoke(struct Client *const source,
 static
 void grant(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
-	if(!HasPrivilege(source_p, "oper:grant"))
+	if(MyClient(source_p) && !HasPrivilege(source_p, "oper:grant"))
 	{
 		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "grant");
 		return;
@@ -129,7 +129,7 @@ void grant(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source
 		return;
 	}
 
-	if(!find_shared_conf(source_p->username, source_p->host, source_p->servptr->name, SHARED_GRANT))
+	if(!MyClient(source_p) && !find_shared_conf(source_p->username, source_p->host, source_p->servptr->name, SHARED_GRANT))
 	{
 		sendto_one_notice(source_p, ":GRANT failed: You have no shared configuration block on this server.");
 		return;


### PR DESCRIPTION
Added 2 checks on "MyClient(source_p)", as the modules used to:
- Check if the source has "oper:grant" even if it's a remote client.
- Check if there was a proper shared{} block, even if the oper is a local client.