### PR TITLE
Improve the OpenSSL backend

### DIFF
--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -582,10 +582,13 @@ rb_ssl_write(rb_fde_t *const F, const void *const buf, const size_t count)
 static void
 rb_ssl_connect_realcb(rb_fde_t *const F, const int status, struct ssl_connect *const sconn)
 {
+	lrb_assert(F->connect != NULL);
+
 	F->connect->callback = sconn->callback;
 	F->connect->data = sconn->data;
-	rb_free(sconn);
+
 	rb_connect_callback(F, status);
+	rb_free(sconn);
 }
 
 static void

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -259,11 +259,12 @@ rb_ssl_shutdown(rb_fde_t *const F)
 
 	(void) rb_ssl_last_err();
 
-	SSL_set_shutdown(SSL_P(F), SSL_RECEIVED_SHUTDOWN);
-
 	for(int i = 0; i < 4; i++)
 	{
-		if(SSL_shutdown(SSL_P(F)))
+		int ret = SSL_shutdown(SSL_P(F));
+		int err = SSL_get_error(SSL_P(F), ret);
+
+		if(ret >= 0 || (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE))
 			break;
 	}
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -183,11 +183,11 @@ rb_ssl_tryconn_cb(rb_fde_t *const F, void *const data)
 static const char *
 rb_ssl_strerror(unsigned long err)
 {
-	static char buf[512];
+	static char errbuf[512];
 
-	ERR_error_string_n(err, buf, sizeof buf);
+	ERR_error_string_n(err, errbuf, sizeof errbuf);
 
-	return buf;
+	return errbuf;
 }
 
 static int

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -367,14 +367,12 @@ rb_ssl_shutdown(rb_fde_t *const F)
 int
 rb_init_ssl(void)
 {
-	/*
-	 * OpenSSL 1.1.0 and above automatically initialises itself with sane defaults
-	 */
-	#if defined(LIBRESSL_VERSION_NUMBER) || (OPENSSL_VERSION_NUMBER < 0x10100000L)
-	SSL_library_init();
+#ifndef LRB_SSL_NO_EXPLICIT_INIT
+	(void) SSL_library_init();
 	SSL_load_error_strings();
-	#endif
+#endif
 
+	rb_lib_log("%s: OpenSSL backend initialised", __func__);
 	return 1;
 }
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -360,7 +360,7 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 		}
 	}
 
-	if (SSL_CTX_set_cipher_list(ssl_ctx_new, cipherlist) != 1)
+	if(SSL_CTX_set_cipher_list(ssl_ctx_new, cipherlist) != 1)
 	{
 		rb_lib_log("%s: SSL_CTX_set_cipher_list: could not configure any ciphers", __func__);
 		SSL_CTX_free(ssl_ctx_new);

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -35,6 +35,15 @@
 
 static SSL_CTX *ssl_ctx = NULL;
 
+struct ssl_connect
+{
+	CNCB *callback;
+	void *data;
+	int timeout;
+};
+
+static void rb_ssl_connect_realcb(rb_fde_t *, int, struct ssl_connect *);
+
 static unsigned long
 get_last_err(void)
 {
@@ -428,13 +437,6 @@ rb_ssl_listen(rb_fde_t *F, int backlog, int defer_accept)
 
 	return result;
 }
-
-struct ssl_connect
-{
-	CNCB *callback;
-	void *data;
-	int timeout;
-};
 
 static void
 rb_ssl_connect_realcb(rb_fde_t *F, int status, struct ssl_connect *sconn)

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -592,6 +592,8 @@ static void
 rb_ssl_timeout(rb_fde_t *const F, void *const notused)
 {
 	lrb_assert(F->accept != NULL);
+	lrb_assert(F->accept->callback != NULL);
+
 	F->accept->callback(F, RB_ERR_TIMEOUT, NULL, 0, F->accept->data);
 }
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -669,9 +669,9 @@ rb_ssl_accept_setup(rb_fde_t *const srv_F, rb_fde_t *const cli_F, struct sockadd
 	cli_F->accept = rb_malloc(sizeof(struct acceptdata));
 	cli_F->accept->callback = srv_F->accept->callback;
 	cli_F->accept->data = srv_F->accept->data;
-	cli_F->accept->addrlen = addrlen;
+	cli_F->accept->addrlen = (rb_socklen_t) addrlen;
 	(void) memset(&cli_F->accept->S, 0x00, sizeof cli_F->accept->S);
-	(void) memcpy(&cli_F->accept->S, st, addrlen);
+	(void) memcpy(&cli_F->accept->S, st, (size_t) addrlen);
 
 	rb_settimeout(cli_F, 10, rb_ssl_timeout, NULL);
 	rb_ssl_init_fd(cli_F, RB_FD_TLS_DIRECTION_IN);

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -318,7 +318,7 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 	if(SSL_CTX_use_certificate_chain_file(ssl_ctx_new, certfile) != 1)
 	{
 		rb_lib_log("%s: SSL_CTX_use_certificate_chain_file ('%s'): %s", __func__, certfile,
-			   rb_ssl_strerror(rb_ssl_last_err()));
+		           rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
 		return 0;
@@ -327,7 +327,7 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 	if(SSL_CTX_use_PrivateKey_file(ssl_ctx_new, keyfile, SSL_FILETYPE_PEM) != 1)
 	{
 		rb_lib_log("%s: SSL_CTX_use_PrivateKey_file ('%s'): %s", __func__, keyfile,
-			   rb_ssl_strerror(rb_ssl_last_err()));
+		           rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
 		return 0;

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -724,4 +724,4 @@ rb_ssl_start_connected(rb_fde_t *const F, CNCB *const callback, void *const data
 	rb_ssl_tryconn_cb(F, sconn);
 }
 
-#endif /* HAVE_OPESSL */
+#endif /* HAVE_OPENSSL */

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -311,14 +311,13 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 
 	if(ssl_ctx_new == NULL)
 	{
-		rb_lib_log("%s: Unable to initialize OpenSSL context: %s", __func__,
-			   rb_ssl_strerror(rb_ssl_last_err()));
+		rb_lib_log("%s: SSL_CTX_new: %s", __func__, rb_ssl_strerror(rb_ssl_last_err()));
 		return 0;
 	}
 
 	if(SSL_CTX_use_certificate_chain_file(ssl_ctx_new, certfile) != 1)
 	{
-		rb_lib_log("%s: Error loading certificate file ('%s'): %s", __func__, certfile,
+		rb_lib_log("%s: SSL_CTX_use_certificate_chain_file ('%s'): %s", __func__, certfile,
 			   rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
@@ -327,7 +326,7 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 
 	if(SSL_CTX_use_PrivateKey_file(ssl_ctx_new, keyfile, SSL_FILETYPE_PEM) != 1)
 	{
-		rb_lib_log("%s: Error loading keyfile ('%s'): %s", __func__, keyfile,
+		rb_lib_log("%s: SSL_CTX_use_PrivateKey_file ('%s'): %s", __func__, keyfile,
 			   rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
@@ -345,11 +344,11 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 
 		if(dhf == NULL)
 		{
-			rb_lib_log("%s: Error loading DH params file ('%s'): %s", __func__, dhfile, strerror(errno));
+			rb_lib_log("%s: fopen ('%s'): %s", __func__, dhfile, strerror(errno));
 		}
 		else if(PEM_read_DHparams(dhf, &dhp, NULL, NULL) == NULL)
 		{
-			rb_lib_log("%s: Error loading DH params file ('%s'): %s", __func__, dhfile,
+			rb_lib_log("%s: PEM_read_DHparams ('%s'): %s", __func__, dhfile,
 			           rb_ssl_strerror(rb_ssl_last_err()));
 			fclose(dhf);
 		}

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -440,6 +440,7 @@ rb_init_prng(const char *const path, prng_seed_t seed_type)
 		return 0;
 	}
 
+	rb_lib_log("%s: PRNG initialised", __func__);
 	return 1;
 }
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -181,7 +181,7 @@ rb_ssl_tryconn_cb(rb_fde_t *const F, void *const data)
 }
 
 static const char *
-rb_ssl_strerror(unsigned long err)
+rb_ssl_strerror(const unsigned long err)
 {
 	static char errbuf[512];
 

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -68,7 +68,7 @@ get_last_err(void)
 }
 
 static void
-rb_ssl_accept_common(rb_fde_t *new_F)
+rb_ssl_accept_common(rb_fde_t *const new_F)
 {
 	int ssl_err;
 	if((ssl_err = SSL_accept((SSL *) new_F->ssl)) <= 0)
@@ -99,12 +99,11 @@ rb_ssl_accept_common(rb_fde_t *new_F)
 }
 
 static void
-rb_ssl_tryaccept(rb_fde_t *F, void *data)
+rb_ssl_tryaccept(rb_fde_t *const F, void *const data)
 {
 	int ssl_err;
 	lrb_assert(F->accept != NULL);
 	int flags;
-	struct acceptdata *ad;
 
 	if(!SSL_is_init_finished((SSL *) F->ssl))
 	{
@@ -137,17 +136,16 @@ rb_ssl_tryaccept(rb_fde_t *F, void *data)
 	rb_settimeout(F, 0, NULL, NULL);
 	rb_setselect(F, RB_SELECT_READ | RB_SELECT_WRITE, NULL, NULL);
 
-	ad = F->accept;
+	struct acceptdata *const ad = F->accept;
 	F->accept = NULL;
 	ad->callback(F, RB_OK, (struct sockaddr *)&ad->S, ad->addrlen, ad->data);
 	rb_free(ad);
-
 }
 
 static void
-rb_ssl_tryconn_cb(rb_fde_t *F, void *data)
+rb_ssl_tryconn_cb(rb_fde_t *const F, void *const data)
 {
-	struct ssl_connect *sconn = data;
+	struct ssl_connect *const sconn = data;
 	int ssl_err;
 	if(!SSL_is_init_finished((SSL *) F->ssl))
 	{
@@ -180,9 +178,9 @@ rb_ssl_tryconn_cb(rb_fde_t *F, void *data)
 }
 
 static void
-rb_ssl_tryconn(rb_fde_t *F, int status, void *data)
+rb_ssl_tryconn(rb_fde_t *const F, const int status, void *const data)
 {
-	struct ssl_connect *sconn = data;
+	struct ssl_connect *const sconn = data;
 	int ssl_err;
 	if(status != RB_OK)
 	{
@@ -232,17 +230,17 @@ get_ssl_error(unsigned long err)
 }
 
 static int
-verify_accept_all_cb(int preverify_ok, X509_STORE_CTX *x509_ctx)
+verify_accept_all_cb(const int preverify_ok, X509_STORE_CTX *const x509_ctx)
 {
 	return 1;
 }
 
 static ssize_t
-rb_ssl_read_or_write(int r_or_w, rb_fde_t *F, void *rbuf, const void *wbuf, size_t count)
+rb_ssl_read_or_write(const int r_or_w, rb_fde_t *const F, void *const rbuf, const void *const wbuf, const size_t count)
 {
 	ssize_t ret;
 	unsigned long err;
-	SSL *ssl = F->ssl;
+	SSL *const ssl = F->ssl;
 
 	if(r_or_w == 0)
 		ret = (ssize_t) SSL_read(ssl, rbuf, (int)count);
@@ -291,7 +289,7 @@ rb_ssl_read_or_write(int r_or_w, rb_fde_t *F, void *rbuf, const void *wbuf, size
  */
 
 void
-rb_ssl_shutdown(rb_fde_t *F)
+rb_ssl_shutdown(rb_fde_t *const F)
 {
 	int i;
 	if(F == NULL || F->ssl == NULL)
@@ -324,7 +322,7 @@ rb_init_ssl(void)
 }
 
 int
-rb_setup_ssl_server(const char *cert, const char *keyfile, const char *dhfile, const char *cipher_list)
+rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *const dhfile, const char *cipher_list)
 {
 	if(cert == NULL)
 	{
@@ -389,7 +387,7 @@ rb_setup_ssl_server(const char *cert, const char *keyfile, const char *dhfile, c
 	 * Set manual ECDHE curve on OpenSSL 1.0.0 & 1.0.1, but make sure it's actually available
 	 */
 	#if (OPENSSL_VERSION_NUMBER >= 0x10000000L) && (OPENSSL_VERSION_NUMBER < 0x10002000L) && !defined(OPENSSL_NO_ECDH)
-	EC_KEY *key = EC_KEY_new_by_curve_name(NID_secp384r1);
+	EC_KEY *const key = EC_KEY_new_by_curve_name(NID_secp384r1);
 	if(key) {
 		SSL_CTX_set_tmp_ecdh(ssl_ctx_new, key);
 		EC_KEY_free(key);
@@ -419,7 +417,7 @@ rb_setup_ssl_server(const char *cert, const char *keyfile, const char *dhfile, c
 	if(dhfile != NULL)
 	{
 		/* DH parameters aren't necessary, but they are nice..if they didn't pass one..that is their problem */
-		FILE *fp = fopen(dhfile, "r");
+		FILE *const fp = fopen(dhfile, "r");
 		DH *dh = NULL;
 
 		if(fp == NULL)
@@ -450,7 +448,7 @@ rb_setup_ssl_server(const char *cert, const char *keyfile, const char *dhfile, c
 }
 
 int
-rb_init_prng(const char *path, prng_seed_t seed_type)
+rb_init_prng(const char *const path, prng_seed_t seed_type)
 {
 	if(seed_type == RB_PRNG_DEFAULT)
 	{
@@ -481,7 +479,7 @@ rb_init_prng(const char *path, prng_seed_t seed_type)
 }
 
 int
-rb_get_random(void *buf, size_t length)
+rb_get_random(void *const buf, const size_t length)
 {
 	int ret;
 
@@ -494,17 +492,16 @@ rb_get_random(void *buf, size_t length)
 }
 
 const char *
-rb_get_ssl_strerror(rb_fde_t *F)
+rb_get_ssl_strerror(rb_fde_t *const F)
 {
 	return get_ssl_error(F->ssl_errno);
 }
 
 int
-rb_get_ssl_certfp(rb_fde_t *F, uint8_t certfp[RB_SSL_CERTFP_LEN], int method)
+rb_get_ssl_certfp(rb_fde_t *const F, uint8_t certfp[const RB_SSL_CERTFP_LEN], const int method)
 {
 	const EVP_MD *evp;
 	unsigned int len;
-	X509 *cert;
 	int res;
 
 	if(F->ssl == NULL)
@@ -528,7 +525,7 @@ rb_get_ssl_certfp(rb_fde_t *F, uint8_t certfp[RB_SSL_CERTFP_LEN], int method)
 		return 0;
 	}
 
-	cert = SSL_get_peer_certificate((SSL *) F->ssl);
+	X509 *const cert = SSL_get_peer_certificate((SSL *) F->ssl);
 	if(cert == NULL)
 		return 0;
 
@@ -554,7 +551,7 @@ rb_get_ssl_certfp(rb_fde_t *F, uint8_t certfp[RB_SSL_CERTFP_LEN], int method)
 }
 
 void
-rb_get_ssl_info(char *buf, size_t len)
+rb_get_ssl_info(char *const buf, const size_t len)
 {
 #ifdef LRB_SSL_FULL_VERSION_INFO
 	if (LRB_SSL_VNUM_RUNTIME == LRB_SSL_VNUM_COMPILETIME)
@@ -571,15 +568,15 @@ rb_get_ssl_info(char *buf, size_t len)
 }
 
 const char *
-rb_ssl_get_cipher(rb_fde_t *F)
+rb_ssl_get_cipher(rb_fde_t *const F)
 {
 	if(F == NULL || F->ssl == NULL)
 		return NULL;
 
 	static char buf[512];
 
-	const char *version = SSL_get_version(F->ssl);
-	const char *cipher = SSL_get_cipher_name(F->ssl);
+	const char *const version = SSL_get_version(F->ssl);
+	const char *const cipher = SSL_get_cipher_name(F->ssl);
 
 	(void) rb_snprintf(buf, sizeof buf, "%s, %s", version, cipher);
 
@@ -587,19 +584,19 @@ rb_ssl_get_cipher(rb_fde_t *F)
 }
 
 ssize_t
-rb_ssl_read(rb_fde_t *F, void *buf, size_t count)
+rb_ssl_read(rb_fde_t *const F, void *const buf, const size_t count)
 {
 	return rb_ssl_read_or_write(0, F, buf, NULL, count);
 }
 
 ssize_t
-rb_ssl_write(rb_fde_t *F, const void *buf, size_t count)
+rb_ssl_write(rb_fde_t *const F, const void *const buf, const size_t count)
 {
 	return rb_ssl_read_or_write(1, F, NULL, buf, count);
 }
 
 void
-rb_ssl_start_accepted(rb_fde_t *new_F, ACCB * cb, void *data, int timeout)
+rb_ssl_start_accepted(rb_fde_t *const new_F, ACCB *const cb, void *const data, const int timeout)
 {
 	new_F->type |= RB_FD_SSL;
 	new_F->ssl = SSL_new(ssl_ctx);
@@ -616,7 +613,7 @@ rb_ssl_start_accepted(rb_fde_t *new_F, ACCB * cb, void *data, int timeout)
 }
 
 void
-rb_ssl_accept_setup(rb_fde_t *F, rb_fde_t *new_F, struct sockaddr *st, int addrlen)
+rb_ssl_accept_setup(rb_fde_t *const F, rb_fde_t *const new_F, struct sockaddr *const st, const int addrlen)
 {
 	new_F->type |= RB_FD_SSL;
 	new_F->ssl = SSL_new(ssl_ctx);
@@ -634,17 +631,18 @@ rb_ssl_accept_setup(rb_fde_t *F, rb_fde_t *new_F, struct sockaddr *st, int addrl
 }
 
 void
-rb_ssl_start_connected(rb_fde_t *F, CNCB * callback, void *data, int timeout)
+rb_ssl_start_connected(rb_fde_t *const F, CNCB *const callback, void *const data, const int timeout)
 {
-	struct ssl_connect *sconn;
-	int ssl_err;
 	if(F == NULL)
 		return;
 
-	sconn = rb_malloc(sizeof(struct ssl_connect));
+	int ssl_err;
+
+	struct ssl_connect *const sconn = rb_malloc(sizeof *sconn);
 	sconn->data = data;
 	sconn->callback = callback;
 	sconn->timeout = timeout;
+
 	F->connect = rb_malloc(sizeof(struct conndata));
 	F->connect->callback = callback;
 	F->connect->data = data;
@@ -687,7 +685,7 @@ rb_ssl_start_connected(rb_fde_t *F, CNCB * callback, void *data, int timeout)
  */
 
 static void
-rb_ssl_connect_realcb(rb_fde_t *F, int status, struct ssl_connect *sconn)
+rb_ssl_connect_realcb(rb_fde_t *const F, const int status, struct ssl_connect *const sconn)
 {
 	F->connect->callback = sconn->callback;
 	F->connect->data = sconn->data;
@@ -696,14 +694,14 @@ rb_ssl_connect_realcb(rb_fde_t *F, int status, struct ssl_connect *sconn)
 }
 
 static void
-rb_ssl_timeout(rb_fde_t *F, void *notused)
+rb_ssl_timeout(rb_fde_t *const F, void *const notused)
 {
 	lrb_assert(F->accept != NULL);
 	F->accept->callback(F, RB_ERR_TIMEOUT, NULL, 0, F->accept->data);
 }
 
 static void
-rb_ssl_tryconn_timeout_cb(rb_fde_t *F, void *data)
+rb_ssl_tryconn_timeout_cb(rb_fde_t *const F, void *const data)
 {
 	rb_ssl_connect_realcb(F, RB_ERR_TIMEOUT, data);
 }
@@ -721,19 +719,19 @@ rb_supports_ssl(void)
 }
 
 unsigned int
-rb_ssl_handshake_count(rb_fde_t *F)
+rb_ssl_handshake_count(rb_fde_t *const F)
 {
 	return F->handshake_count;
 }
 
 void
-rb_ssl_clear_handshake_count(rb_fde_t *F)
+rb_ssl_clear_handshake_count(rb_fde_t *const F)
 {
 	F->handshake_count = 0;
 }
 
 int
-rb_ssl_listen(rb_fde_t *F, int backlog, int defer_accept)
+rb_ssl_listen(rb_fde_t *const F, const int backlog, const int defer_accept)
 {
 	int result;
 
@@ -744,19 +742,18 @@ rb_ssl_listen(rb_fde_t *F, int backlog, int defer_accept)
 }
 
 void
-rb_connect_tcp_ssl(rb_fde_t *F, struct sockaddr *dest,
-		   struct sockaddr *clocal, int socklen, CNCB * callback, void *data, int timeout)
+rb_connect_tcp_ssl(rb_fde_t *const F, struct sockaddr *const dest, struct sockaddr *const clocal,
+                   const int socklen, CNCB *const callback, void *const data, const int timeout)
 {
-	struct ssl_connect *sconn;
 	if(F == NULL)
 		return;
 
-	sconn = rb_malloc(sizeof(struct ssl_connect));
+	struct ssl_connect *const sconn = rb_malloc(sizeof *sconn);
 	sconn->data = data;
 	sconn->callback = callback;
 	sconn->timeout = timeout;
-	rb_connect_tcp(F, dest, clocal, socklen, rb_ssl_tryconn, sconn, timeout);
 
+	rb_connect_tcp(F, dest, clocal, socklen, rb_ssl_tryconn, sconn, timeout);
 }
 
 #endif /* HAVE_OPESSL */

--- a/libratbox/src/openssl.c
+++ b/libratbox/src/openssl.c
@@ -381,13 +381,13 @@ rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *con
 {
 	if(cert == NULL)
 	{
-		rb_lib_log("rb_setup_ssl_server: No certificate file");
+		rb_lib_log("%s: no certificate file specified", __func__);
 		return 0;
 	}
 
 	if(keyfile == NULL)
 	{
-		rb_lib_log("rb_setup_ssl_server: No key file");
+		rb_lib_log("%s: no key file specified", __func__);
 		return 0;
 	}
 
@@ -405,7 +405,7 @@ rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *con
 
 	if(ssl_ctx_new == NULL)
 	{
-		rb_lib_log("rb_init_openssl: Unable to initialize OpenSSL context: %s",
+		rb_lib_log("%s: Unable to initialize OpenSSL context: %s", __func__,
 			   rb_ssl_strerror(rb_ssl_last_err()));
 		return 0;
 	}
@@ -456,7 +456,7 @@ rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *con
 
 	if(! SSL_CTX_use_certificate_chain_file(ssl_ctx_new, cert))
 	{
-		rb_lib_log("rb_setup_ssl_server: Error loading certificate file [%s]: %s", cert,
+		rb_lib_log("%s: Error loading certificate file [%s]: %s", __func__, cert,
 			   rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
@@ -465,7 +465,7 @@ rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *con
 
 	if(! SSL_CTX_use_PrivateKey_file(ssl_ctx_new, keyfile, SSL_FILETYPE_PEM))
 	{
-		rb_lib_log("rb_setup_ssl_server: Error loading keyfile [%s]: %s", keyfile,
+		rb_lib_log("%s: Error loading keyfile [%s]: %s", __func__, keyfile,
 			   rb_ssl_strerror(rb_ssl_last_err()));
 
 		SSL_CTX_free(ssl_ctx_new);
@@ -480,12 +480,12 @@ rb_setup_ssl_server(const char *const cert, const char *keyfile, const char *con
 
 		if(fp == NULL)
 		{
-			rb_lib_log("rb_setup_ssl_server: Error loading DH params file [%s]: %s",
+			rb_lib_log("%s: Error loading DH params file [%s]: %s", __func__,
 			           dhfile, strerror(errno));
 		}
 		else if(PEM_read_DHparams(fp, &dh, NULL, NULL) == NULL)
 		{
-			rb_lib_log("rb_setup_ssl_server: Error loading DH params file [%s]: %s",
+			rb_lib_log("%s: Error loading DH params file [%s]: %s", __func__,
 			           dhfile, rb_ssl_strerror(rb_ssl_last_err()));
 			fclose(fp);
 		}

--- a/libratbox/src/openssl_ratbox.h
+++ b/libratbox/src/openssl_ratbox.h
@@ -1,0 +1,102 @@
+/*
+ *  libratbox: a library used by ircd-ratbox and other things
+ *  openssl_ratbox.h: OpenSSL backend data
+ *
+ *  Copyright (C) 2015-2016 Aaron Jones <aaronmdjones@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ *
+ */
+
+#ifndef LRB_OPENSSL_H_INC
+#define LRB_OPENSSL_H_INC 1
+
+#include <openssl/dh.h>
+#include <openssl/ec.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
+
+#include <openssl/opensslv.h>
+
+/*
+ * A long time ago, in a world far away, OpenSSL had a well-established mechanism for ensuring compatibility with
+ * regards to added, changed, and removed functions, by having an SSLEAY_VERSION_NUMBER macro. This was then
+ * renamed to OPENSSL_VERSION_NUMBER, but the old macro was kept around for compatibility until OpenSSL version
+ * 1.1.0.
+ *
+ * Then the OpenBSD developers decided that having OpenSSL in their codebase was a bad idea. They forked it to
+ * create LibreSSL, gutted all of the functionality they didn't want or need, and generally improved the library
+ * a lot. Then, as the OpenBSD developers are want to do, they packaged up LibreSSL for release to other
+ * operating systems, as LibreSSL Portable. Think along the lines of OpenSSH where they have also done this.
+ *
+ * The fun part of this story ends there. LibreSSL has an OPENSSL_VERSION_NUMBER macro, but they have set it to a
+ * stupidly high value, version 2.0. OpenSSL version 2.0 does not exist, and LibreSSL 2.2 does not implement
+ * everything OpenSSL 1.0.2 or 1.1.0 do. This completely breaks the entire purpose of the macro.
+ *
+ * The ifdef soup below is for LibreSSL compatibility. Please find whoever thought setting OPENSSL_VERSION_NUMBER
+ * to a version that does not exist was a good idea. Encourage them to realise that it is not.   -- amdj
+ */
+
+#if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#  define LRB_SSL_NO_EXPLICIT_INIT      1
+#endif
+
+#if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10002000L)
+#  define LRB_HAVE_TLS_SET_CURVES       1
+#  if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#    define LRB_HAVE_TLS_ECDH_AUTO      1
+#  endif
+#endif
+
+#if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x20020002L)
+#  define LRB_HAVE_TLS_METHOD_API       1
+#else
+#  if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#    define LRB_HAVE_TLS_METHOD_API     1
+#  endif
+#endif
+
+#if !defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#  define LRB_SSL_VTEXT_COMPILETIME     OPENSSL_VERSION_TEXT
+#  define LRB_SSL_VTEXT_RUNTIME         OpenSSL_version(OPENSSL_VERSION)
+#  define LRB_SSL_VNUM_COMPILETIME      OPENSSL_VERSION_NUMBER
+#  define LRB_SSL_VNUM_RUNTIME          OpenSSL_version_num()
+#  define LRB_SSL_FULL_VERSION_INFO     1
+#else
+#  if defined(LIBRESSL_VERSION_NUMBER) && (LIBRESSL_VERSION_NUMBER >= 0x20200000L)
+#    define LRB_SSL_VTEXT_RUNTIME       SSLeay_version(SSLEAY_VERSION)
+#    define LRB_SSL_VNUM_COMPILETIME    LIBRESSL_VERSION_NUMBER
+#  else
+#    define LRB_SSL_VTEXT_RUNTIME       SSLeay_version(SSLEAY_VERSION)
+#    define LRB_SSL_VNUM_COMPILETIME    SSLEAY_VERSION_NUMBER
+#  endif
+#endif
+
+
+
+/*
+ * Default supported ciphersuites (if the user does not provide any) and curves (OpenSSL 1.0.2+)
+ * Hardcoded secp384r1 (P-384) is used on OpenSSL 1.0.0 and 1.0.1 (if available).
+ */
+
+static const char rb_default_ciphers[] = "kEECDH+HIGH:kEDH+HIGH:HIGH:!aNULL";
+#ifdef LRB_HAVE_TLS_SET_CURVES
+static const char rb_default_curves[] = "P-521:P-384:P-256";
+#endif
+
+#endif /* LRB_OPENSSL_H_INC */


### PR DESCRIPTION
This is along the same line of work I've done to the MbedTLS backend.

The diff between the current MbedTLS backend and this OpenSSL backend is fairly small -- if you exclude the obvious differences between the libraries (required structures, function names, variable types, etc) the difference is almost non-existent.

I have done extensive testing but I don't claim to have caught everything wrong. It needs review.

A similar series of edits will be proposed for the GNUTLS backend soon; see also issue #215.