### PR TITLE
Added kick immunity to umode +p (oper-override)

### DIFF
--- a/extensions/override.c
+++ b/extensions/override.c
@@ -98,7 +98,7 @@ expire_override_deadlines(void *unused)
 			break;
 		else if (session_p->deadline < rb_current_time())
 		{
-		        const char *parv[4] = {session_p->client->name, session_p->client->name, "-p", NULL};
+			const char *parv[4] = {session_p->client->name, session_p->client->name, "-p", NULL};
 			user_mode(session_p->client, session_p->client, 3, parv);
 		}
 	}
@@ -201,6 +201,33 @@ hack_can_kick(void *vdata)
 	hook_data_channel_approval *data = (hook_data_channel_approval *) vdata;
 	int alevel;
 
+	if (data->target->umodes & user_modes['p'])
+	{
+		if (data->client->umodes & user_modes['p'])
+		{
+			/* Using oper-override to kick an oper
+			 * who's also using oper-override, better
+			 * report what happened.
+			 */
+			update_session_deadline(data->client, NULL);
+			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s is using oper-override on %s (KICK %s)",
+					       get_oper_name(data->client), data->chptr->chname, data->target->name);
+		}
+		else
+		{
+			/* Like cmode +M, let's report any attempt
+			 * to kick the immune oper.
+			 */
+			update_session_deadline(data->target, NULL);
+			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s attempted to kick %s from %s (who is +p)",
+				data->client->name, data->target->name, data->chptr->chname);
+			sendto_one_numeric(data->client, ERR_ISCHANSERVICE, "%s %s :Cannot kick immune IRC operators.",
+				data->target->name, data->chptr->chname);
+			data->approved = 0;
+		}
+		return;
+	}
+
 	alevel = get_channel_access(data->client, data->chptr, data->msptr, data->dir, NULL);
 	if (alevel != CHFL_OVERRIDE)
 		return;
@@ -265,7 +292,7 @@ _modinit(void)
 	user_modes['p'] = find_umode_slot();
 	construct_umodebuf();
 
-        expire_override_deadlines_ev = rb_event_add("expire_override_deadlines", expire_override_deadlines, NULL, 60);
+	expire_override_deadlines_ev = rb_event_add("expire_override_deadlines", expire_override_deadlines, NULL, 60);
 
 	return 0;
 }


### PR DESCRIPTION
So, there's been a little debate about this feature being added to +p.
I can understand why it can be considered as a philosophical issue.

Here's why I still wanted to submit this pull-request:
- The umode +p is already considered as the immune user mode in Atheme.  
https://github.com/atheme/atheme/blob/master/modules/protocol/charybdis.c#L95
- You can already bypass bans and quiets with it, kick immunity would (in my opinion) be somewhat logical, as an oper usually uses +p to lift almost all limits.
- There is already cmode +M, but it is channel-wide and protects all opers, where +p is network-wide and would obviously protect only the oper having it.

For the unethical part, cmode +M is already granting an immunity and is not even visible to the users, except when +M channels are not secret as you can still list them by modes using services like ALIS. If this pull-request is considered as too problematic, Atheme should then stop considering umode +p as the immunity user mode because it would them be an incoherence, especially since Atheme is able to understand +M (atheme/atheme#504).

If you disagree with my point of view, please tell me your arguments.