### PR TITLE
B feature + fix package.

### DIFF
--- a/bandb/bandb.c
+++ b/bandb/bandb.c
@@ -247,7 +247,7 @@ error_cb(rb_helper *helper)
 	exit(1);
 }
 
-#ifndef WINDOWS
+#ifndef _WIN32
 static void
 dummy_handler(int sig)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -35,11 +35,11 @@ build_ltdl=$with_included_ltdl
 AM_CONDITIONAL([BUILD_LTDL], [test x"$build_ltdl" = x"yes"])
 
 case "$host_os" in
-*cygwin*)
+*cygwin* | *msys*)
      AC_DEFINE_UNQUOTED(CYGWIN,1,[This is a Cygwin system])
      AC_DEFINE_UNQUOTED(WINDOWS,1,[This is a Windows system])
      ;;
-*mingw* | *msys*)
+*mingw*)
      AC_DEFINE_UNQUOTED(MINGW,1,[This is a MinGW system])
      AC_DEFINE_UNQUOTED(WINDOWS,1,[This is a Windows system])
      AC_CHECK_HEADER(winsock2.h, , [AC_MSG_ERROR([** MinGW and no winsock2.h.  I give up.])])

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -477,7 +477,8 @@ operator "god" {
 	/* name: the name of the oper must go above */
 
 	/* user: the user@host required for this operator.  CIDR *is*
-	 * supported now. auth{} spoofs work here, other spoofs do not.
+	 * supported now. auth{} spoofs work here, other spoofs only
+	 * work if explicitly enabled (see: flags).
 	 * multiple user="" lines are supported.
 	 */
 	user = "*god@*";
@@ -521,6 +522,10 @@ operator "god" {
 	 *
 	 * encrypted:    the password above is encrypted [DEFAULT]
 	 * need_ssl:     must be using SSL/TLS to oper up
+	 * vhost_auth:   allow softer spoofs in user= [SECURITY RISK]
+	 *               WARNING: vhost_auth option allows anyone on
+	 *               the network who can issue a CHGHOST to match
+	 *               this oper's user@host. Use with care.
 	 */
 	flags = encrypted;
 

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -139,11 +139,13 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 			int cap, const char *format, ...);
 
 #define OPER_ENCRYPTED	0x00001
+#define OPER_VHOSTAUTH	0x00002
 #define OPER_NEEDSSL    0x80000
 
 #define OPER_FLAGS	0	 /* no oper privs in Client.flags/oper_conf.flags currently */
 
 #define IsOperConfEncrypted(x)	((x)->flags & OPER_ENCRYPTED)
+#define IsOperConfVHostAuth(x)	((x)->flags & OPER_VHOSTAUTH)
 #define IsOperConfNeedSSL(x)	((x)->flags & OPER_NEEDSSL)
 
 #define HasPrivilege(x, y)	((x)->localClient != NULL && (x)->localClient->privset != NULL && privilegeset_in_set((x)->localClient->privset, (y)))
@@ -170,7 +172,7 @@ extern struct oper_conf *make_oper_conf(void);
 extern void free_oper_conf(struct oper_conf *);
 extern void clear_oper_conf(void);
 
-extern struct oper_conf *find_oper_conf(const char *username, const char *host,
+extern struct oper_conf *find_oper_conf(const char *username, const char *host, const char *vhost,
 					const char *locip, const char *oname);
 
 extern const char *get_oper_privs(int flags);

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -335,6 +335,7 @@ static struct mode_table umode_table[] = {
 static struct mode_table oper_table[] = {
 	{"encrypted",		OPER_ENCRYPTED		},
 	{"need_ssl",		OPER_NEEDSSL		},
+	{"vhost_auth",		OPER_VHOSTAUTH		},
 	{NULL, 0}
 };
 

--- a/ircd/s_newconf.c
+++ b/ircd/s_newconf.c
@@ -282,7 +282,7 @@ free_oper_conf(struct oper_conf *oper_p)
 }
 
 struct oper_conf *
-find_oper_conf(const char *username, const char *host, const char *locip, const char *name)
+find_oper_conf(const char *username, const char *host, const char *vhost, const char *locip, const char *name)
 {
 	struct oper_conf *oper_p;
 	struct rb_sockaddr_storage ip, cip;
@@ -314,6 +314,9 @@ find_oper_conf(const char *username, const char *host, const char *locip, const 
 		 * in ip form to sockhost will not necessarily match --anfl
 		 */
 		if(match(oper_p->host, host))
+			return oper_p;
+
+		if((oper_p->flags & OPER_VHOSTAUTH) && !EmptyString(vhost) && match(oper_p->host, vhost))
 			return oper_p;
 	}
 

--- a/librb/configure.ac
+++ b/librb/configure.ac
@@ -58,11 +58,11 @@ AC_PROG_LIBTOOL
 LIBTOOL="$LIBTOOL --silent"
 
 case "$host_os" in
-*cygwin*)
+*cygwin* | *msys*)
      AC_DEFINE_UNQUOTED(CYGWIN,1,[This is a Cygwin system])
      AC_DEFINE_UNQUOTED(WINDOWS,1,[This is a Windows system])
      ;;
-*mingw* | *msys*)
+*mingw*)
      AC_DEFINE_UNQUOTED(MINGW,1,[This is a MinGW system])
      AC_DEFINE_UNQUOTED(WINDOWS,1,[This is a Windows system])
      AC_CHECK_HEADER(windows.h, , [AC_MSG_ERROR([** MinGW and no windows.h.  I give up.])])

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -53,6 +53,7 @@ auto_load_mod_LTLIBRARIES = \
   m_rehash.la \
   m_restart.la \
   m_resv.la \
+  m_sajoin.la \
   m_sasl.la \
   m_scan.la \
   m_services.la \

--- a/modules/m_challenge.c
+++ b/modules/m_challenge.c
@@ -167,7 +167,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 
 		rb_free(b_response);
 
-		oper_p = find_oper_conf(source_p->username, source_p->orighost,
+		oper_p = find_oper_conf(source_p->username, source_p->orighost, source_p->host,
 					source_p->sockhost,
 					source_p->localClient->opername);
 
@@ -199,7 +199,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 
 	cleanup_challenge(source_p);
 
-	oper_p = find_oper_conf(source_p->username, source_p->orighost,
+	oper_p = find_oper_conf(source_p->username, source_p->orighost, source_p->host,
 				source_p->sockhost, parv[1]);
 
 	if(oper_p == NULL)

--- a/modules/m_oper.c
+++ b/modules/m_oper.c
@@ -79,7 +79,7 @@ m_oper(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	if(!IsFloodDone(source_p))
 		flood_endgrace(source_p);
 
-	oper_p = find_oper_conf(source_p->username, source_p->orighost,
+	oper_p = find_oper_conf(source_p->username, source_p->orighost, source_p->host,
 				source_p->sockhost, name);
 
 	if(oper_p == NULL)

--- a/modules/m_sajoin.c
+++ b/modules/m_sajoin.c
@@ -1,0 +1,149 @@
+/*
+ *  charybdis: porto vintage '88.
+ *  m_sajoin.c: Force join a user to a channel.
+ *
+ * Copyright (c) 2016 Charybdis Development Team
+ * Copyright (c) 2016 Jason Volk <jason@zemos.net>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for 
+any
+ * purpose with or without fee is hereby granted, provided that the 
+above
+ * copyright notice and this permission notice is present in all copies.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "stdinc.h"
+#include "client.h"
+#include "ircd.h"
+#include "msg.h"
+#include "numeric.h"
+#include "send.h"
+#include "s_conf.h"
+#include "logger.h"
+#include "parse.h"
+#include "modules.h"
+#include "hash.h"
+#include "cache.h"
+#include "rb_dictionary.h"
+
+const char sajoin_desc[] =
+"Allows operators to force a user to join a channel.";
+
+static void mo_sajoin(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
+
+struct Message sajoin_msgtab =
+{
+	"SAJOIN", 0, 0, 0, 0,
+	{
+		mg_unreg,
+		mg_ignore,
+		mg_ignore,
+		mg_ignore,
+		mg_ignore,
+		{ mo_sajoin, 3 }
+	}
+};
+
+mapi_clist_av1 sajoin_clist[] =
+{
+	&sajoin_msgtab,
+	NULL
+};
+
+DECLARE_MODULE_AV2
+(
+	sajoin,
+	NULL,
+	NULL,
+	sajoin_clist,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	sajoin_desc
+);
+
+/* Soft join is where SAJOIN peruses as the user itself attempting
+ * to join the channel and is susceptible to bans etc.
+ *
+ * parv[1] = user to join to channel
+ * parv[2] = name of channel
+ */
+static void
+join_soft(struct Client *const client,
+          const char *const chname)
+{
+	static char buf[BUFSIZE];
+	const size_t len = snprintf(buf, sizeof(buf), ":%s JOIN %s",
+	                            use_id(client),
+	                            chname);
+
+	parse(client, buf, buf + len);
+}
+
+/* Hard join forces the target user into the channel manually,
+ * with as few checks as possible to bypass any bans etc.
+ *
+ * parv[1] = user to join to channel
+ * parv[2] = name of channel
+ *
+ *  !! NOT YET IMPLEMENTED !!
+ */
+static void
+join_hard(struct Client *const client,
+          const char *const chname)
+{
+}
+
+/*
+ * parv[1] = channel list (chan,chan,chan,...)
+ * parv[2] = nick list (nick,nick,nick,...)
+ * (future) parv[3] = options
+ */
+static void
+mo_sajoin(struct MsgBuf *const msgbuf,
+          struct Client *const client_p,
+          struct Client *const source_p,
+          int parc,
+          const char **const parv)
+{
+	static const char *const SEP = ",";
+	static char vec[BUFSIZE];
+	char *ctx, *target;
+
+	int clients = 0;
+	static struct Client *client[BUFSIZE];
+	rb_strlcpy(vec, parv[2], sizeof(vec));
+	target = rb_strtok_r(vec, SEP, &ctx); do
+	{
+		if(!(client[clients] = find_person(target)))
+			continue;
+
+		clients++;		
+	}
+	while((target = rb_strtok_r(NULL, SEP, &ctx)));
+
+	rb_strlcpy(vec, parv[1], sizeof(vec));
+	target = rb_strtok_r(vec, SEP, &ctx); do
+	{
+		if(!check_channel_name(target))
+			continue;
+
+		for(size_t i = 0; i < clients; i++)
+			join_soft(client[i], target);
+	}
+	while((target = rb_strtok_r(NULL, SEP, &ctx)));
+}


### PR DESCRIPTION
* Feature: Option to match oper confs based on vhost.
- Looks finished; includes the security warnings

* Feature: SAJOIN command to force.
- Minimalistic, but might be enough for now.
- "Hard" sajoins might not be possible without significant work to abstract m_join code.

* Fix: This diff was necessary for me to build on a Windows10/msys2 platform. I'm not really sure why, actually, and maybe this should be looked into before merging...