### PR TITLE
properly call gnutls_x509_crt_list_import

### DIFF
--- a/libratbox/src/gnutls.c
+++ b/libratbox/src/gnutls.c
@@ -540,6 +540,7 @@ rb_setup_ssl_server(const char *const certfile, const char *keyfile,
 		rb_free_datum_t(d_key);
 		return 0;
 	}
+	client_cert_count = MAX_CERTS;
 	if((ret = gnutls_x509_crt_list_import(client_cert, &client_cert_count, d_cert, GNUTLS_X509_FMT_PEM,
 	                                      GNUTLS_X509_CRT_LIST_IMPORT_FAIL_IF_EXCEED)) < 1)
 	{


### PR DESCRIPTION
the [manpage][] says:

>  unsigned int * cert_max
>      Initially must hold the maximum number of certs. It will be updated
>      with the number of certs available.

ratbox doesn't actually initialize that variable, so gnutls naturally
fails. i would also recommend considering dynamically allocating the
cert list to deal with that error in other ways than failing to
configured SSL completely in GnuTLS. the apache gnutls module has a
similar problem and came up with a [patch][] to do exactly this which
you may want to consider.

but since our cert chain is only (!) 5 certs long, our itched is
scratch by this particular patch.

[manpage]: https://manpages.debian.org/jessie/gnutls-doc/gnutls_x509_crt_list_import.3.en.html
[patch]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=511573#35