### PR TITLE
modules/m_sasl: Also check if the server the SASL agent is on has split from the network, to properly advertise the loss of the "sasl" cap for clients that support cap-notify. (Charybdis 4.1.x master)

### DIFF
--- a/modules/m_sasl.c
+++ b/modules/m_sasl.c
@@ -1,6 +1,7 @@
 /* modules/m_sasl.c
  *   Copyright (C) 2006 Michael Tharp <gxti@partiallystapled.com>
  *   Copyright (C) 2006 charybdis development team
+ *   Copyright (C) 2016 ChatLounge IRC Network Development Team
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -338,11 +339,22 @@ advertise_sasl(struct Client *client_p)
 static void
 advertise_sasl_exit(hook_data_client_exit *data)
 {
+	/* Check to see whether the server the SASL agent has dropped,
+	 * or whether the SASL agent has /quit (as it would or should,
+	 * if unloaded).
+	 *
+	 * Ben
+	 */
+
 	if (!ConfigFileEntry.sasl_service)
 		return;
 
-	if (irccmp(data->target->name, ConfigFileEntry.sasl_service))
+	struct Client *sasl_p;
+
+	if((sasl_p = find_named_client(ConfigFileEntry.sasl_service)) == NULL)
 		return;
 
-	sendto_local_clients_with_capability(CLICAP_CAP_NOTIFY, ":%s CAP * DEL :sasl", me.name);
+	if (irccmp(data->target->name, sasl_p->servptr->name) == 0 ||
+		irccmp(data->target->name, ConfigFileEntry.sasl_service) == 0)
+		sendto_local_clients_with_capability(CLICAP_CAP_NOTIFY, ":%s CAP * DEL :sasl", me.name);
 }


### PR DESCRIPTION
Previously, it would only check if the SASL agent has quit, which normally only occurs if the SASL agent is unloaded.  In Atheme and ChatServices, if services are restarted, the services server splits from the network.  This means removal of the "sasl" cap never gets advertised to clients that support cap-notify, despite the loss of the capability.

This pull request updates Charybdis 4.1.x (master).