### PR TITLE
YESNO options are of type bool, not int

### DIFF
--- a/ircd/getopt.c
+++ b/ircd/getopt.c
@@ -64,7 +64,7 @@ parseargs(int *argc, char * const **argv, struct lgetopt *opts)
 				switch (opts[i].argtype)
 				{
 				case YESNO:
-					*((int *) opts[i].argloc) = 1;
+					*((bool *) opts[i].argloc) = TRUE;
 					break;
 				case INTEGER:
 					if(*argc < 2)


### PR DESCRIPTION
This causes memory corruption on modern compilers, and crashes under `-fsanitize=address`.

Fixes #259.