### PR TITLE
point users towards HELP EXTBAN for inline help

### DIFF
--- a/doc/oper-guide/cmodes.rst
+++ b/doc/oper-guide/cmodes.rst
@@ -35,7 +35,7 @@ optionally preceded by a tilde (``~``) to negate the comparison. data
 depends on type.  Each type is loaded as a module. The available types
 (if any) are listed in the ``EXTBAN`` token of the 005
 (``RPL_ISUPPORT``) numeric. See ``doc/extban.txt`` in the source
-distribution for more information.
+distribution or ``HELP EXTBAN`` for more information.
 
 If no parameter is given, the list of bans is returned. All users can
 use this form. The plus sign should also be omitted.


### PR DESCRIPTION
I'd love to have that merged in 4.x but the oper guide is completely missing from there, see #258