### PR TITLE
Added usermode +h for IRC Operators to display Unreal swhois.

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -36,6 +36,14 @@
 #loadmodule "extensions/override.so";
 #loadmodule "extensions/no_kill_services.so";
 
+/* This is new in charybdis
+ * sets swhois "is available for help."
+ * in the /whois of the IRC Operator who is modded
+ * +h on!
+ */ 
+
+loadmodule "extensions/m_helpop.so";
+
 /*
  * IP cloaking extensions: use ip_cloaking_4.0
  * if you're linking 3.2 and later, otherwise use
@@ -474,6 +482,14 @@ general {
 	 *	default_umodes = "+ih";
 	 */
 	default_umodes = "+i";
+  
+        /* This is the configuration block for the HELPOP module, 
+         * If it is loaded, you can carry on, if it isn't loaded, kindly
+         * uncomment the following lines:
+         */
+
+        helpopstring = "is available for help.";
+        helpop_unreal_loc = yes;
 
 	default_operstring = "is an IRC Operator";
 	default_adminstring = "is a Server Administrator";

--- a/extensions/Makefile.in
+++ b/extensions/Makefile.in
@@ -50,6 +50,7 @@ SRCS =                          \
   extb_oper.c			\
   extb_server.c			\
   extb_ssl.c			\
+  m_helpop.c                    \
   extb_realname.c		\
   extb_usermode.c		\
   extb_extgecos.c		\

--- a/extensions/m_helpop.c
+++ b/extensions/m_helpop.c
@@ -1,0 +1,94 @@
+/*
+ * "is available for help." for charybdis 3.6.
+ * modular for obvious reasons. (not worth coring it)
+ */
+
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "hash.h"
+#include "s_conf.h"
+#include "s_user.h"
+#include "s_serv.h"
+#include "numeric.h"
+#include "privilege.h"
+#include "s_newconf.h"
+#include "newconf.h"
+
+
+static void h_helpop_whois(hook_data_client *);
+static void h_helpop_high_whois(hook_data_client *);
+mapi_hfn_list_av1 whois_helpop_hfnlist[] = {
+	{ "doing_whois",	(hookfn) h_helpop_whois },
+	{ "doing_whois_global",	(hookfn) h_helpop_whois },
+	{ "doing_whois_top",	(hookfn) h_helpop_high_whois },
+	{ "doing_whois_top_global",	(hookfn) h_helpop_high_whois },
+	{ NULL, NULL }
+};
+
+static void check_umode_change(void *data);
+char *helpopstring = "";
+char helpoploc = 0;
+
+#define IsUnrealStyle()	(helpoploc != 0)
+#define IsChatdStyle()	(helpoploc == 0)
+
+static void
+conf_set_helpopstring(void *data)
+{
+	helpopstring = rb_strdup(data);
+}
+
+static void
+conf_set_helpoploc(void *data)
+{
+	helpoploc = *(unsigned int *)data;
+}
+
+static void
+helpop_whois(hook_data_client *data)
+{
+	if(!EmptyString(helpopstring) && IsHelpOp(data->target))
+	{
+		sendto_one_numeric(data->client, RPL_WHOISSPECIAL,
+				form_str(RPL_WHOISSPECIAL),
+				data->target->name, helpopstring);
+	}
+}
+
+static void h_helpop_whois (hook_data_client *data)
+{
+	if (IsChatdStyle()) helpop_whois(data);
+}
+
+static void h_helpop_high_whois (hook_data_client *data)
+{
+	if (IsUnrealStyle()) helpop_whois(data);
+}
+
+static int
+_modinit(void)
+{
+	/* add the usermode to the available slot */
+	add_conf_item("general", "helpopstring", CF_QSTRING, conf_set_helpopstring);
+	add_conf_item("general", "helpop_unreal_loc", CF_YESNO, conf_set_helpoploc);
+	construct_umodebuf();
+
+	return 0;
+}
+
+static void
+_moddeinit(void)
+{
+	/* disable the umode and remove it from the available list */
+	remove_conf_item("general", "helpopstring");
+	remove_conf_item("general", "helpop_unreal_loc");
+	construct_umodebuf();
+}
+
+DECLARE_MODULE_AV1(whois_helpop, _modinit, _moddeinit, NULL, NULL,
+			whois_helpop_hfnlist, "$Revision: 3526 $");
+

--- a/include/client.h
+++ b/include/client.h
@@ -427,6 +427,7 @@ struct ListClient
 #define UMODE_DEAF	   0x0080
 #define UMODE_NOFORWARD    0x0100	/* don't forward */
 #define UMODE_REGONLYMSG   0x0200	/* only allow logged in users to msg */
+#define UMODE_HELPOP	   0x0400	/* show in stats p */
 
 /* user information flags, only settable by remote mode or local oper */
 #define UMODE_OPER         0x1000	/* Operator */
@@ -530,6 +531,7 @@ struct ListClient
 #define IsDeaf(x)		((x)->umodes & UMODE_DEAF)
 #define IsNoForward(x)		((x)->umodes & UMODE_NOFORWARD)
 #define IsSetRegOnlyMsg(x)	((x)->umodes & UMODE_REGONLYMSG)
+#define IsHelpOp(x)		((x)->umodes & UMODE_HELPOP) /* new in charybdis 3.5 */
 
 #define SetGotId(x)             ((x)->flags |= FLAGS_GOTID)
 #define IsGotId(x)              (((x)->flags & FLAGS_GOTID) != 0)

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -160,6 +160,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperRehash(x)         (HasPrivilege((x), "oper:rehash"))
 #define IsOperHiddenAdmin(x)    (HasPrivilege((x), "oper:hidden_admin"))
 #define IsOperAdmin(x)          (HasPrivilege((x), "oper:admin") || HasPrivilege((x), "oper:hidden_admin"))
+#define IsOperHelper(x)         HasPrivilege(x, "oper:helpop")
 #define IsOperOperwall(x)       (HasPrivilege((x), "oper:operwall"))
 #define IsOperSpy(x)            (HasPrivilege((x), "oper:spy"))
 #define IsOperInvis(x)          (HasPrivilege((x), "oper:hidden"))

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -788,6 +788,9 @@ stats_operedup (struct Client *source_p)
 	RB_DLINK_FOREACH (oper_ptr, oper_list.head)
 	{
 		target_p = oper_ptr->data;
+      
+                if(!IsHelpOp(target_p))
+			continue;
 
 		if(IsOperInvis(target_p) && !IsOper(source_p))
 			continue;

--- a/src/newconf.c
+++ b/src/newconf.c
@@ -328,6 +328,7 @@ static struct mode_table umode_table[] = {
 	{"servnotice",	UMODE_SERVNOTICE},
 	{"wallop",	UMODE_WALLOP	},
 	{"operwall",	UMODE_OPERWALL	},
+        {"helpop",	UMODE_HELPOP	},
 	{NULL, 0}
 };
 

--- a/src/s_user.c
+++ b/src/s_user.c
@@ -102,7 +102,7 @@ int user_modes[256] = {
 	0,			/* e */
 	0,			/* f */
 	UMODE_CALLERID,		/* g */
-	0,			/* h */
+        UMODE_HELPOP,		/* h */
 	UMODE_INVISIBLE,	/* i */
 	0,			/* j */
 	0,			/* k */
@@ -1119,6 +1119,12 @@ user_mode(struct Client *client_p, struct Client *source_p, int parc, const char
 	{
 		sendto_one_notice(source_p, ":*** You need oper and operwall flag for +z");
 		source_p->umodes &= ~UMODE_OPERWALL;
+	}
+
+        if(MyClient(source_p) && (source_p->umodes & UMODE_HELPOP) && !IsOperHelper(source_p))
+	{
+		sendto_one_notice(source_p, ":*** You need oper and helpop flag for +h");
+		source_p->umodes &= ~UMODE_HELPOP;
 	}
 
 	if(MyConnect(source_p) && (source_p->umodes & UMODE_ADMIN) &&


### PR DESCRIPTION
Hi folks,
I was thinking of why couldn't we get UnrealIRCd's swhois when a person modes on +h in charybdis?
Believing in this possibility of this could be done, here, I am opening a **Pull Request** for the same.
**FEATURES**
* When an IRC Operator modes himself +h on! it displays a swhois **"is available for help."** in the /swhois.
* Non-IRC Operators cant set themselves +h
* it is in fully synchronisation with /stats p, if a oper is hidden, then this swhois could be only seen by IRC operators.