### PR TITLE
librb/event: delete indirectly via a dead flag

### DIFF
--- a/librb/include/event-int.h
+++ b/librb/include/event-int.h
@@ -33,5 +33,6 @@ struct ev_entry
 	time_t next;
 	void *data;
 	void *comm_ptr;
+	int dead;
 };
 void rb_event_io_register_all(void);


### PR DESCRIPTION
This avoids an issue where deleting an event inside the handler of a different event puts the event iteration in an invalid state.