### PR TITLE
override: move kick immunity to its own module

### DIFF
--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -40,7 +40,8 @@ extension_LTLIBRARIES =		\
   ip_cloaking_3.0.la		\
   ip_cloaking_4.0.la		\
   override.la			\
-  restrict-unauthenticated.la    \
+  override_kick_immunity.la	\
+  restrict-unauthenticated.la	\
   sno_channelcreate.la		\
   sno_farconnect.la		\
   sno_globalkline.la		\

--- a/extensions/override.c
+++ b/extensions/override.c
@@ -201,33 +201,6 @@ hack_can_kick(void *vdata)
 	hook_data_channel_approval *data = (hook_data_channel_approval *) vdata;
 	int alevel;
 
-	if (data->target->umodes & user_modes['p'])
-	{
-		if (data->client->umodes & user_modes['p'])
-		{
-			/* Using oper-override to kick an oper
-			 * who's also using oper-override, better
-			 * report what happened.
-			 */
-			update_session_deadline(data->client, NULL);
-			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s is using oper-override on %s (KICK %s)",
-					       get_oper_name(data->client), data->chptr->chname, data->target->name);
-		}
-		else
-		{
-			/* Like cmode +M, let's report any attempt
-			 * to kick the immune oper.
-			 */
-			update_session_deadline(data->target, NULL);
-			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s attempted to kick %s from %s (who is +p)",
-				data->client->name, data->target->name, data->chptr->chname);
-			sendto_one_numeric(data->client, ERR_ISCHANSERVICE, "%s %s :Cannot kick immune IRC operators.",
-				data->target->name, data->chptr->chname);
-			data->approved = 0;
-		}
-		return;
-	}
-
 	alevel = get_channel_access(data->client, data->chptr, data->msptr, data->dir, NULL);
 	if (alevel != CHFL_OVERRIDE)
 		return;

--- a/extensions/override_kick_immunity.c
+++ b/extensions/override_kick_immunity.c
@@ -1,0 +1,53 @@
+#include "stdinc.h"
+#include "modules.h"
+#include "hook.h"
+#include "client.h"
+#include "ircd.h"
+#include "send.h"
+#include "numeric.h"
+#include "s_user.h"
+#include "s_conf.h"
+
+static const char override_kick_immunity_desc[] =
+	"Prevents +p users (oper override) from being kicked from any channel";
+
+static void can_kick(void *data);
+
+mapi_hfn_list_av1 override_kick_immunity_hfnlist[] = {
+	{ "can_kick", (hookfn) can_kick },
+	{ NULL, NULL }
+};
+
+static void
+can_kick(void *vdata)
+{
+	hook_data_channel_approval *data = vdata;
+
+	if (data->target->umodes & user_modes['p'])
+	{
+		if (data->client->umodes & user_modes['p'])
+		{
+			/* Using oper-override to kick an oper
+			 * who's also using oper-override, better
+			 * report what happened.
+			 */
+			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s is using oper-override on %s (KICK %s)",
+					get_oper_name(data->client), data->chptr->chname, data->target->name);
+		}
+		else
+		{
+			/* Like cmode +M, let's report any attempt
+			 * to kick the immune oper.
+			 */
+			sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s attempted to kick %s from %s (who is +p)",
+				data->client->name, data->target->name, data->chptr->chname);
+			sendto_one_numeric(data->client, ERR_ISCHANSERVICE, "%s %s :Cannot kick immune IRC operators.",
+				data->target->name, data->chptr->chname);
+			data->approved = 0;
+		}
+		return;
+	}
+}
+
+DECLARE_MODULE_AV2(override_kick_immunity, NULL, NULL, NULL, NULL,
+			override_kick_immunity_hfnlist, NULL, NULL, override_kick_immunity_desc);


### PR DESCRIPTION
I see kick immunity and override as quite different things, and want override but not kick immunity, but network administrators who want the new-old behaviour back can `loadmodule "extensions/override_kick_immunity"`.