### PR TITLE
Deferred capability notifications from modules

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -122,6 +122,10 @@ struct mapi_mheader_av2
 void mod_add_path(const char *path);
 void mod_clear_paths(void);
 
+/* cap-notify utilities */
+extern void mod_remember_clicaps(void);
+extern void mod_notify_clicaps(void);
+
 /* load a module */
 extern void load_module(char *path);
 

--- a/modules/core/m_modules.c
+++ b/modules/core/m_modules.c
@@ -274,8 +274,12 @@ do_modload(struct Client *source_p, const char *module)
 		return;
 	}
 
+	mod_remember_clicaps();
+
 	origin = strcmp(module, m_bn) == 0 ? MAPI_ORIGIN_CORE : MAPI_ORIGIN_EXTENSION;
 	load_one_module(module, origin, false);
+
+	mod_notify_clicaps();
 
 	rb_free(m_bn);
 }
@@ -300,8 +304,12 @@ do_modunload(struct Client *source_p, const char *module)
 		return;
 	}
 
+	mod_remember_clicaps();
+
 	if(unload_one_module(m_bn, true) == false)
 		sendto_one_notice(source_p, ":Module %s is not loaded", m_bn);
+
+	mod_notify_clicaps();
 
 	rb_free(m_bn);
 }
@@ -322,6 +330,8 @@ do_modreload(struct Client *source_p, const char *module)
 
 	check_core = mod->core;
 
+	mod_remember_clicaps();
+
 	if(unload_one_module(m_bn, true) == false)
 	{
 		sendto_one_notice(source_p, ":Module %s is not loaded", m_bn);
@@ -336,6 +346,8 @@ do_modreload(struct Client *source_p, const char *module)
 		ilog(L_MAIN, "Error loading core module %s: terminating ircd", m_bn);
 		exit(0);
 	}
+
+	mod_notify_clicaps();
 
 	rb_free(m_bn);
 }


### PR DESCRIPTION
Reloading modules sends CAP DEL followed by an immediate CAP NEW:

    :staberinde.local CAP * DEL :account-tag
    :staberinde.local CAP * NEW :account-tag

This isn't very nice. /modrestart is particularly bad. In order to avoid
doing this, we remember the capability set at the beginning of module
operations, compare that with the set afterwards, and report only the
differences with CAP {DEL,NEW}.