### PR TITLE
Propagate OPER

### DIFF
--- a/doc/technical/ts6-protocol.txt
+++ b/doc/technical/ts6-protocol.txt
@@ -670,6 +670,13 @@ and most error messages are suppressed.
 Servers may not send '$$', '$#' and opers@server notices. Older servers may
 not allow servers to send to specific statuses on a channel.
 
+OPER
+source: user
+parameters: opername, privset
+
+Sets the source user's oper name and privset. Sent after the +o mode change, or
+during burst, to inform other servers of an oper's privileges.
+
 OPERSPY
 encap only
 encap target: *
@@ -1222,7 +1229,6 @@ MODRESTART
 MODUNLOAD
 MONITOR
 NAMES
-OPER
 POST
 PUT
 RESTART

--- a/extensions/extb_oper.c
+++ b/extensions/extb_oper.c
@@ -42,7 +42,7 @@ static int eb_oper(const char *data, struct Client *client_p,
 	if (data != NULL)
 	{
 		struct PrivilegeSet *set = privilegeset_get(data);
-		if (set != NULL && client_p->localClient->privset == set)
+		if (set != NULL && client_p->user->privset == set)
 			return EXTBAN_MATCH;
 
 		/* $o:admin or whatever */

--- a/include/client.h
+++ b/include/client.h
@@ -79,6 +79,9 @@ struct User
 	char *away;		/* pointer to away message */
 	int refcnt;		/* Number of times this block is referenced */
 
+	char *opername; /* name of operator{} block being used or tried (challenge) */
+	struct PrivilegeSet *privset;
+
 	char suser[NICKLEN+1];
 };
 
@@ -225,7 +228,6 @@ struct LocalUser
 	 */
 	char *passwd;
 	char *auth_user;
-	char *opername; /* name of operator{} block being used or tried (challenge) */
 	char *challenge;
 	char *fullcaps;
 	char *cipher_string;
@@ -281,8 +283,6 @@ struct LocalUser
 	struct ZipStats *zipstats;		/* zipstats */
 	uint16_t cork_count;			/* used for corking/uncorking connections */
 	struct ev_entry *event;			/* used for associated events */
-
-	struct PrivilegeSet *privset;		/* privset... */
 
 	char sasl_agent[IDLEN];
 	unsigned char sasl_out;

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -146,7 +146,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperConfEncrypted(x)	((x)->flags & OPER_ENCRYPTED)
 #define IsOperConfNeedSSL(x)	((x)->flags & OPER_NEEDSSL)
 
-#define HasPrivilege(x, y)	((x)->localClient != NULL && (x)->localClient->privset != NULL && privilegeset_in_set((x)->localClient->privset, (y)))
+#define HasPrivilege(x, y)	((x)->user != NULL && (x)->user->privset != NULL && privilegeset_in_set((x)->user->privset, (y)))
 
 #define IsOperGlobalKill(x)     (HasPrivilege((x), "oper:global_kill"))
 #define IsOperLocalKill(x)      (HasPrivilege((x), "oper:local_kill"))

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -300,10 +300,7 @@ free_local_client(struct Client *client_p)
 	rb_free(client_p->localClient->auth_user);
 	rb_free(client_p->localClient->challenge);
 	rb_free(client_p->localClient->fullcaps);
-	rb_free(client_p->localClient->opername);
 	rb_free(client_p->localClient->mangledhost);
-	if (client_p->localClient->privset)
-		privilegeset_unref(client_p->localClient->privset);
 
 	if (IsSSL(client_p))
 		ssld_decrement_clicount(client_p->localClient->ssl_ctl);
@@ -1920,6 +1917,9 @@ free_user(struct User *user, struct Client *client_p)
 	{
 		if(user->away)
 			rb_free((char *) user->away);
+		rb_free(user->opername);
+		if (user->privset)
+			privilegeset_unref(user->privset);
 		/*
 		 * sanity check
 		 */

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1267,7 +1267,7 @@ get_oper_name(struct Client *client_p)
 	{
 		snprintf(buffer, sizeof(buffer), "%s!%s@%s{%s}",
 				client_p->name, client_p->username,
-				client_p->host, client_p->localClient->opername);
+				client_p->host, client_p->user->opername);
 		return buffer;
 	}
 

--- a/ircd/s_serv.c
+++ b/ircd/s_serv.c
@@ -669,6 +669,12 @@ burst_TS6(struct Client *client_p)
 				   use_id(target_p),
 				   target_p->user->away);
 
+		if(IsOper(target_p) && target_p->user && target_p->user->opername && target_p->user->privset)
+			sendto_one(client_p, ":%s OPER %s %s",
+					use_id(target_p),
+					target_p->user->opername,
+					target_p->user->privset->name);
+
 		hclientinfo.target = target_p;
 		call_hook(h_burst_client, &hclientinfo);
 	}

--- a/modules/m_challenge.c
+++ b/modules/m_challenge.c
@@ -93,9 +93,9 @@ cleanup_challenge(struct Client *target_p)
 		return;
 
 	rb_free(target_p->localClient->challenge);
-	rb_free(target_p->localClient->opername);
+	rb_free(target_p->user->opername);
 	target_p->localClient->challenge = NULL;
-	target_p->localClient->opername = NULL;
+	target_p->user->opername = NULL;
 	target_p->localClient->chal_time = 0;
 }
 
@@ -131,7 +131,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		{
 			sendto_one(source_p, form_str(ERR_PASSWDMISMATCH), me.name, source_p->name);
 			ilog(L_FOPER, "EXPIRED CHALLENGE (%s) by (%s!%s@%s) (%s)",
-			     source_p->localClient->opername, source_p->name,
+			     source_p->user->opername, source_p->name,
 			     source_p->username, source_p->host, source_p->sockhost);
 
 			if(ConfigFileEntry.failed_oper_notice)
@@ -151,7 +151,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		{
 			sendto_one(source_p, form_str(ERR_PASSWDMISMATCH), me.name, source_p->name);
 			ilog(L_FOPER, "FAILED CHALLENGE (%s) by (%s!%s@%s) (%s)",
-			     source_p->localClient->opername, source_p->name,
+			     source_p->user->opername, source_p->name,
 			     source_p->username, source_p->host, source_p->sockhost);
 
 			if(ConfigFileEntry.failed_oper_notice)
@@ -169,13 +169,13 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 
 		oper_p = find_oper_conf(source_p->username, source_p->orighost,
 					source_p->sockhost,
-					source_p->localClient->opername);
+					source_p->user->opername);
 
 		if(oper_p == NULL)
 		{
 			sendto_one_numeric(source_p, ERR_NOOPERHOST, form_str(ERR_NOOPERHOST));
 			ilog(L_FOPER, "FAILED OPER (%s) by (%s!%s@%s) (%s)",
-			     source_p->localClient->opername, source_p->name,
+			     source_p->user->opername, source_p->name,
 			     source_p->username, source_p->host,
 			     source_p->sockhost);
 
@@ -192,7 +192,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		oper_up(source_p, oper_p);
 
 		ilog(L_OPERED, "OPER %s by %s!%s@%s (%s)",
-		     source_p->localClient->opername, source_p->name,
+		     source_p->user->opername, source_p->name,
 		     source_p->username, source_p->host, source_p->sockhost);
 		return;
 	}
@@ -274,7 +274,7 @@ m_challenge(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 		sendto_one(source_p, form_str(RPL_ENDOFRSACHALLENGE2),
 			   me.name, source_p->name);
 		rb_free(challenge);
-		source_p->localClient->opername = rb_strdup(oper_p->name);
+		source_p->user->opername = rb_strdup(oper_p->name);
 	}
 	else
 		sendto_one_notice(source_p, ":Failed to generate challenge.");

--- a/modules/m_grant.c
+++ b/modules/m_grant.c
@@ -61,7 +61,7 @@ void set_privset(struct Client *const source,
 		return;
 	}
 
-	if(IsOper(target) && target->localClient->privset == privset)
+	if(IsOper(target) && target->user->privset == privset)
 	{
 		sendto_one_notice(source, ":%s already has role of %s.", target->name, privset_name);
 		return;
@@ -71,7 +71,7 @@ void set_privset(struct Client *const source,
 	{
 		sendto_one_notice(target, ":%s has changed your role to %s.", source->name, privset_name);
 		sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s has changed %s's role to %s.", get_oper_name(source), target->name, privset_name);
-		target->localClient->privset = privset;
+		target->user->privset = privset;
 		return;
 	}
 

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -318,11 +318,14 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 				    GlobalSetOptions.operstring));
 	}
 
-	if(MyClient(target_p) && !EmptyString(target_p->localClient->opername) && IsOper(target_p) && IsOper(source_p))
+	if(!EmptyString(target_p->user->opername) && IsOper(target_p) && IsOper(source_p))
 	{
 		char buf[512];
+		const char *privset = "(missing)";
+		if (target_p->user->privset != NULL)
+			privset = target_p->user->privset->name;
 		snprintf(buf, sizeof(buf), "is opered as %s, privset %s",
-			    target_p->localClient->opername, target_p->localClient->privset->name);
+			    target_p->user->opername, privset);
 		sendto_one_numeric(source_p, RPL_WHOISSPECIAL, form_str(RPL_WHOISSPECIAL),
 				   target_p->name, buf);
 	}

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -3898,8 +3898,8 @@ static void sendto_realops_snomask1(void)
 	oper3->snomask = SNO_BOTS | SNO_SKILL;
 	oper4->snomask = SNO_GENERAL | SNO_REJ;
 
-	oper3->localClient->privset = privilegeset_get("admin");
-	oper4->localClient->privset = privilegeset_get("admin");
+	oper3->user->privset = privilegeset_get("admin");
+	oper4->user->privset = privilegeset_get("admin");
 
 	server->localClient->caps = CAP_ENCAP | CAP_TS6;
 	server2->localClient->caps = 0;
@@ -4125,8 +4125,8 @@ static void sendto_realops_snomask1__tags(void)
 	oper3->snomask = SNO_BOTS | SNO_SKILL;
 	oper4->snomask = SNO_GENERAL | SNO_REJ;
 
-	oper3->localClient->privset = privilegeset_get("admin");
-	oper4->localClient->privset = privilegeset_get("admin");
+	oper3->user->privset = privilegeset_get("admin");
+	oper4->user->privset = privilegeset_get("admin");
 
 	server->localClient->caps = CAP_ENCAP | CAP_TS6;
 	server2->localClient->caps = 0;
@@ -4340,8 +4340,8 @@ static void sendto_realops_snomask_from1(void)
 	oper3->snomask = SNO_BOTS | SNO_SKILL;
 	oper4->snomask = SNO_GENERAL | SNO_REJ;
 
-	oper3->localClient->privset = privilegeset_get("admin");
-	oper4->localClient->privset = privilegeset_get("admin");
+	oper3->user->privset = privilegeset_get("admin");
+	oper4->user->privset = privilegeset_get("admin");
 
 	sendto_realops_snomask_from(SNO_BOTS, L_ALL, &me, "Hello %s!", "World");
 	is_client_sendq(":" TEST_ME_NAME " NOTICE * :*** Notice -- Hello World!" CRLF, oper1, "Matches mask; " MSG);
@@ -4460,8 +4460,8 @@ static void sendto_realops_snomask_from1__tags(void)
 	oper3->snomask = SNO_BOTS | SNO_SKILL;
 	oper4->snomask = SNO_GENERAL | SNO_REJ;
 
-	oper3->localClient->privset = privilegeset_get("admin");
-	oper4->localClient->privset = privilegeset_get("admin");
+	oper3->user->privset = privilegeset_get("admin");
+	oper4->user->privset = privilegeset_get("admin");
 
 	sendto_realops_snomask_from(SNO_BOTS, L_ALL, &me, "Hello %s!", "World");
 	is_client_sendq("@time=" ADVENTURE_TIME " :" TEST_ME_NAME " NOTICE * :*** Notice -- Hello World!" CRLF, oper1, "Matches mask; " MSG);


### PR DESCRIPTION
Move opername and privset storage to struct User, so it can exist for
remote opers.

On /oper and when bursting opers, send:

    :foo OPER opername privset

which sets foo's opername and privset. The contents of the privset on
remote servers come from the remote server's config, so the potential
for confusion exists if these do not match.

If an oper's privset does not exist on a server that sees it, it will
complain, but create a placeholder privset. If the privset is created by
a rehash, this will be reflected properly.

/privs is udpated to take an optional argument, the server to query, and
is now local by default:

    /privs [[nick_or_server] nick]