### PR TITLE
Split oper privs up a bit

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,7 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:general, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,7 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:general, auspex:oper, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:privs, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,8 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall, usermode:servnotice,
+		auspex:oper, auspex:hostname, auspex:umodes, auspex:cmodes;
 };
 
 privset "server_bot" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -247,7 +247,7 @@ privset "server_bot" {
 privset "global_op" {
 	extends = "local_op";
 	privs = oper:global_kill, oper:routing, oper:kline, oper:unkline, oper:xline,
-		oper:resv, oper:mass_notice, oper:remoteban;
+		oper:resv, oper:cmodes, oper:mass_notice, oper:remoteban;
 };
 
 privset "admin" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,7 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:local_kill, oper:operwall;
+	privs = oper:general, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,7 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:general, auspex:oper, oper:privs, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -236,7 +236,7 @@ auth {
  * means they must be defined before operator {}.
  */
 privset "local_op" {
-	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall, usermode:servnotice,
+	privs = oper:general, oper:privs, oper:testline, oper:local_kill, oper:operwall, usermode:servnotice,
 		auspex:oper, auspex:hostname, auspex:umodes, auspex:cmodes;
 };
 

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -463,6 +463,14 @@ privset "local_op" {
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:           allows using the GRANT command
 	 * usermode:servnotice:  allows setting +s
+	 *
+	 * Privileges provided by extensions include:
+	 *
+	 * oper:dehelper:        allows the DEHELPER command (from extensions/helpops)
+	 * oper:override:        enables oper override via umode +p (from extensions/override)
+	 * oper:receive_immunity:
+	 *   confers the benefits of chmode +M (operpeace) (from extensions/chm_operpeace)
+	 * usermode:helpops      allows setting +H (from extensions/helpops)
 	 */
 	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
 };

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -462,6 +462,7 @@ privset "local_op" {
 	 * oper:remoteban:       allows remote kline etc
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:           allows using the GRANT command
+	 * usermode:servnotice:  allows setting +s
 	 */
 	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
 };

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -433,6 +433,7 @@ privset "local_op" {
 	 * oper:general:         enable most general oper privileges that came
 	 *                       with +o in older releases
 	 * auspex:oper:       allows the oper to see through oper hiding
+	 * oper:privs:      allows /stats o/O and seeing privset in /whois
 	 * oper:local_kill:      allows local users to be /KILL'd
 	 * oper:global_kill:     allows local and remote users to be /KILL'd
 	 * oper:routing:         allows remote SQUIT and CONNECT
@@ -458,7 +459,7 @@ privset "local_op" {
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:	         allows using the GRANT command
 	 */
-	privs = oper:general, auspex:oper, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:privs, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -430,6 +430,8 @@ privset "local_op" {
 	 *
 	 * Available options:
 	 *
+	 * oper:general:         enable most general oper privileges that came
+	 *                       with +o in older releases
 	 * oper:local_kill:      allows local users to be /KILL'd
 	 * oper:global_kill:     allows local and remote users to be /KILL'd
 	 * oper:routing:         allows remote SQUIT and CONNECT
@@ -454,7 +456,7 @@ privset "local_op" {
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:	         allows using the GRANT command
 	 */
-	privs = oper:local_kill, oper:operwall;
+	privs = oper:general, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -472,7 +472,8 @@ privset "local_op" {
 	 *   confers the benefits of chmode +M (operpeace) (from extensions/chm_operpeace)
 	 * usermode:helpops      allows setting +H (from extensions/helpops)
 	 */
-	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
+	privs = oper:general, oper:privs, oper:testline, oper:local_kill, oper:operwall, usermode:servnotice,
+		auspex:oper, auspex:hostname, auspex:umodes, auspex:cmodes;
 };
 
 privset "server_bot" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -432,8 +432,11 @@ privset "local_op" {
 	 *
 	 * oper:general:         enable most general oper privileges that came
 	 *                       with +o in older releases
-	 * auspex:oper:       allows the oper to see through oper hiding
-	 * oper:privs:      allows /stats o/O and seeing privset in /whois
+	 * auspex:oper:          allows the oper to see through oper hiding
+	 * auspex:umodes:        allows viewing other users' modes
+	 * auspex:cmodes:        shows privileged cmodes
+	 * auspex:hostname:      shows hidden hostnames/ips
+	 * oper:privs:           allows /stats o/O and seeing privset in /whois
 	 * oper:testline:        allows /testline and /testgecos
 	 * oper:local_kill:      allows local users to be /KILL'd
 	 * oper:global_kill:     allows local and remote users to be /KILL'd
@@ -447,18 +450,18 @@ privset "local_op" {
 	 *                       may (un)load modules and see various
 	 *                       additional information.
 	 * oper:hidden_admin:    gives admin privileges except
-	 *		         will not have the admin lines in
-	 *		         whois.
-	 * oper:xline:	         allows use of /quote xline/unxline
-	 * oper:resv:	         allows /quote resv/unresv
-	 * oper:cmodes           allows cmode +LP
+	 *                       will not have the admin lines in
+	 *                       whois.
+	 * oper:xline:           allows use of /quote xline/unxline
+	 * oper:resv:            allows /quote resv/unresv
+	 * oper:cmodes:          allows cmode +LP
 	 * oper:operwall:        allows the oper to send/receive operwalls
-	 * oper:spy:	         allows 'operspy' features to see through +s
-	 * 		         channels etc. see /quote help operspy
+	 * oper:spy:             allows 'operspy' features to see through +s
+	 *                       channels etc. see /quote help operspy
 	 * oper:hidden:          hides the oper from /stats p
 	 * oper:remoteban:       allows remote kline etc
 	 * oper:mass_notice:     allows sending wallops and mass notices
-	 * oper:grant:	         allows using the GRANT command
+	 * oper:grant:           allows using the GRANT command
 	 */
 	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
 };

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -434,6 +434,7 @@ privset "local_op" {
 	 *                       with +o in older releases
 	 * auspex:oper:       allows the oper to see through oper hiding
 	 * oper:privs:      allows /stats o/O and seeing privset in /whois
+	 * oper:testline:        allows /testline and /testgecos
 	 * oper:local_kill:      allows local users to be /KILL'd
 	 * oper:global_kill:     allows local and remote users to be /KILL'd
 	 * oper:routing:         allows remote SQUIT and CONNECT
@@ -459,7 +460,7 @@ privset "local_op" {
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:	         allows using the GRANT command
 	 */
-	privs = oper:general, auspex:oper, oper:privs, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:privs, oper:testline, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -432,6 +432,7 @@ privset "local_op" {
 	 *
 	 * oper:general:         enable most general oper privileges that came
 	 *                       with +o in older releases
+	 * auspex:oper:       allows the oper to see through oper hiding
 	 * oper:local_kill:      allows local users to be /KILL'd
 	 * oper:global_kill:     allows local and remote users to be /KILL'd
 	 * oper:routing:         allows remote SQUIT and CONNECT
@@ -457,7 +458,7 @@ privset "local_op" {
 	 * oper:mass_notice:     allows sending wallops and mass notices
 	 * oper:grant:	         allows using the GRANT command
 	 */
-	privs = oper:general, oper:local_kill, oper:operwall;
+	privs = oper:general, auspex:oper, oper:local_kill, oper:operwall;
 };
 
 privset "server_bot" {

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -447,7 +447,8 @@ privset "local_op" {
 	 *		         will not have the admin lines in
 	 *		         whois.
 	 * oper:xline:	         allows use of /quote xline/unxline
-	 * oper:resv:	         allows /quote resv/unresv and cmode +LP
+	 * oper:resv:	         allows /quote resv/unresv
+	 * oper:cmodes           allows cmode +LP
 	 * oper:operwall:        allows the oper to send/receive operwalls
 	 * oper:spy:	         allows 'operspy' features to see through +s
 	 * 		         channels etc. see /quote help operspy
@@ -468,7 +469,7 @@ privset "server_bot" {
 privset "global_op" {
 	extends = "local_op";
 	privs = oper:global_kill, oper:routing, oper:kline, oper:unkline, oper:xline,
-		oper:resv, oper:mass_notice, oper:remoteban;
+		oper:resv, oper:cmodes, oper:mass_notice, oper:remoteban;
 };
 
 privset "admin" {

--- a/extensions/chm_operpeace.c
+++ b/extensions/chm_operpeace.c
@@ -58,7 +58,7 @@ hdl_can_kick(hook_data_channel_approval *data)
 	if(IsOper(source_p))
 		return;
 
-	if((chptr->mode.mode & mymode) && IsOper(who))
+	if((chptr->mode.mode & mymode) && HasPrivilege(who, "oper:receive_immunity"))
 	{
 		sendto_realops_snomask(SNO_GENERAL, L_NETWIDE, "%s attempted to kick %s from %s (which is +M)",
 			source_p->name, who->name, chptr->chname);

--- a/extensions/createauthonly.c
+++ b/extensions/createauthonly.c
@@ -15,6 +15,7 @@
 #include "s_conf.h"
 #include "snomask.h"
 #include "numeric.h"
+#include "s_newconf.h"
 
 static const char restrict_desc[] = "Restricts channel creation to authenticated users and IRC operators only";
 
@@ -32,6 +33,6 @@ h_can_create_channel_authenticated(hook_data_client_approval *data)
 {
 	struct Client *source_p = data->client;
 
-	if (*source_p->user->suser == '\0' && !IsOper(source_p))
+	if (*source_p->user->suser == '\0' && !IsOperGeneral(source_p))
 		data->approved = ERR_NEEDREGGEDNICK;
 }

--- a/extensions/createoperonly.c
+++ b/extensions/createoperonly.c
@@ -15,6 +15,7 @@
 #include "s_conf.h"
 #include "snomask.h"
 #include "numeric.h"
+#include "s_newconf.h"
 
 static const char restrict_desc[] = "Restricts channel creation to IRC operators";
 
@@ -32,7 +33,7 @@ h_can_create_channel_authenticated(hook_data_client_approval *data)
 {
 	struct Client *source_p = data->client;
 
-	if (!IsOper(source_p))
+	if (!IsOperGeneral(source_p))
 	{
 		sendto_one_notice(source_p, ":*** Channel creation is restricted to network staff only.");
 		data->approved = ERR_NEEDREGGEDNICK;

--- a/extensions/force_user_invis.c
+++ b/extensions/force_user_invis.c
@@ -32,7 +32,7 @@ h_noi_umode_changed(hook_data_umode_changed *hdata)
 {
 	struct Client *source_p = hdata->client;
 
-	if (MyClient(source_p) && !IsOper(source_p) && !IsInvisible(source_p)) {
+	if (MyClient(source_p) && !IsOperGeneral(source_p) && !IsInvisible(source_p)) {
 		SetInvisible(source_p);
 	}
 }

--- a/extensions/helpops.c
+++ b/extensions/helpops.c
@@ -53,9 +53,9 @@ mo_dehelper(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 {
 	struct Client *target_p;
 
-	if (!IsOperAdmin(source_p))
+	if (!HasPrivilege(source_p, "oper:dehelper"))
 	{
-		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "admin");
+		sendto_one(source_p, form_str(ERR_NOPRIVS), me.name, source_p->name, "dehelper");
 		return;
 	}
 

--- a/extensions/hurt.c
+++ b/extensions/hurt.c
@@ -470,9 +470,9 @@ doing_stats_hook(hook_data_int *hdata)
 	source_p = hdata->client;
 	if(hdata->arg2 != (int) 's')
 		return;
-	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOper(source_p))
+	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOperGeneral(source_p))
 		return;
-	if ((ConfigFileEntry.stats_k_oper_only == 1) && !IsOper(source_p))
+	if ((ConfigFileEntry.stats_k_oper_only == 1) && !IsOperGeneral(source_p))
 	{
 		hurt = hurt_find(source_p->sockhost);
 		if (hurt != NULL)

--- a/extensions/m_findforwards.c
+++ b/extensions/m_findforwards.c
@@ -64,7 +64,7 @@ m_findforwards(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *
 	*p = '\0';
 
 	/* Allow ircops to search for forwards to nonexistent channels */
-	if(!IsOper(source_p))
+	if(!IsOperGeneral(source_p))
 	{
 		if((chptr = find_channel(parv[1])) == NULL || (msptr = find_channel_membership(chptr, source_p)) == NULL)
 		{

--- a/extensions/sno_whois.c
+++ b/extensions/sno_whois.c
@@ -12,6 +12,7 @@
 #include "client.h"
 #include "ircd.h"
 #include "send.h"
+#include "s_newconf.h"
 
 /* undefine this to allow anyone to receive whois notifications */
 #define OPERONLY
@@ -57,7 +58,7 @@ show_whois(hook_data_client *data)
 
 	if(MyClient(target_p) &&
 #ifdef OPERONLY
-	   IsOper(target_p) &&
+	   IsOperGeneral(target_p) &&
 #endif
 	   (source_p != target_p) &&
 	   (target_p->snomask & snomask_modes['W']))

--- a/include/client.h
+++ b/include/client.h
@@ -371,7 +371,7 @@ struct ListClient
 				 (x)->handler = SERVER_HANDLER; }
 
 #define SetClient(x)            {(x)->status = STAT_CLIENT; \
-				 (x)->handler = IsOper((x)) ? \
+				 (x)->handler = IsOperGeneral((x)) ? \
 					OPER_HANDLER : CLIENT_HANDLER; }
 #define SetRemoteClient(x)	{(x)->status = STAT_CLIENT; \
 				 (x)->handler = RCLIENT_HANDLER; }
@@ -516,12 +516,8 @@ struct ListClient
 /* oper flags */
 #define MyOper(x)               (MyConnect(x) && IsOper(x))
 
-#define SetOper(x)              {(x)->umodes |= UMODE_OPER; \
-				 if (MyClient((x))) (x)->handler = OPER_HANDLER;}
-
-#define ClearOper(x)            {(x)->umodes &= ~(UMODE_OPER|UMODE_ADMIN); \
-				 if (MyClient((x)) && !IsOper((x)) && !IsServer((x))) \
-				  (x)->handler = CLIENT_HANDLER; }
+#define SetOper(x)              ((x)->umodes |= UMODE_OPER)
+#define ClearOper(x)            ((x)->umodes &= ~(UMODE_OPER|UMODE_ADMIN))
 
 /* umode flags */
 #define IsInvisible(x)          ((x)->umodes & UMODE_INVISIBLE)

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -165,6 +165,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperInvis(x)          (HasPrivilege((x), "oper:hidden"))
 #define IsOperRemoteBan(x)	(HasPrivilege((x), "oper:remoteban"))
 #define IsOperMassNotice(x)	(HasPrivilege((x), "oper:mass_notice"))
+#define IsOperGeneral(x)	(HasPrivilege((x), "oper:general"))
 
 #define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || IsOper((source))))
 

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -167,7 +167,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperMassNotice(x)	(HasPrivilege((x), "oper:mass_notice"))
 #define IsOperGeneral(x)	(HasPrivilege((x), "oper:general"))
 
-#define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || IsOper((source))))
+#define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || HasPrivilege((source), "auspex:oper")))
 
 extern struct oper_conf *make_oper_conf(void);
 extern void free_oper_conf(struct oper_conf *);

--- a/include/s_newconf.h
+++ b/include/s_newconf.h
@@ -147,6 +147,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperConfNeedSSL(x)	((x)->flags & OPER_NEEDSSL)
 
 #define HasPrivilege(x, y)	((x)->user != NULL && (x)->user->privset != NULL && privilegeset_in_set((x)->user->privset, (y)))
+#define MayHavePrivilege(x, y)	(HasPrivilege((x), (y)) || (IsOper((x)) && (x)->user != NULL && (x)->user->privset == NULL))
 
 #define IsOperGlobalKill(x)     (HasPrivilege((x), "oper:global_kill"))
 #define IsOperLocalKill(x)      (HasPrivilege((x), "oper:local_kill"))
@@ -165,7 +166,7 @@ extern void cluster_generic(struct Client *, const char *, int cltype,
 #define IsOperInvis(x)          (HasPrivilege((x), "oper:hidden"))
 #define IsOperRemoteBan(x)	(HasPrivilege((x), "oper:remoteban"))
 #define IsOperMassNotice(x)	(HasPrivilege((x), "oper:mass_notice"))
-#define IsOperGeneral(x)	(HasPrivilege((x), "oper:general"))
+#define IsOperGeneral(x)	(MayHavePrivilege((x), "oper:general"))
 
 #define SeesOper(target, source)	(IsOper((target)) && ((!ConfigFileEntry.hide_opers && !HasPrivilege((target), "oper:hidden")) || HasPrivilege((source), "auspex:oper")))
 

--- a/include/send.h
+++ b/include/send.h
@@ -59,6 +59,7 @@ extern void sendto_channel_opmod(struct Client *one, struct Client *source_p,
 				 const char *text);
 
 extern void sendto_channel_local(struct Client *, int type, struct Channel *, const char *, ...) AFP(4, 5);
+extern void sendto_channel_local_priv(struct Client *, int type, const char *priv, struct Channel *, const char *, ...) AFP(5, 6);
 extern void sendto_channel_local_butone(struct Client *, int type, struct Channel *, const char *, ...) AFP(4, 5);
 
 extern void sendto_channel_local_with_capability(struct Client *, int type, int caps, int negcaps, struct Channel *, const char *, ...) AFP(6, 7);

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -1122,7 +1122,7 @@ channel_modes(struct Channel *chptr, struct Client *client_p)
 
 	for (i = 0; i < 256; i++)
 	{
-		if(chmode_table[i].set_func == chm_hidden && (!IsOper(client_p) || !IsClient(client_p)))
+		if(chmode_table[i].set_func == chm_hidden && (!HasPrivilege(client_p, "auspex:cmodes") || !IsClient(client_p)))
 			continue;
 		if(chptr->mode.mode & chmode_flags[i])
 			*mbuf++ = i;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -660,7 +660,7 @@ chm_hidden(struct Client *source_p, struct Channel *chptr,
 	  int alevel, int parc, int *parn,
 	  const char **parv, int *errors, int dir, char c, long mode_type)
 {
-	if(!IsOper(source_p) && !IsServer(source_p))
+	if(!IsOperGeneral(source_p) && !IsServer(source_p))
 	{
 		if(!(*errors & SM_ERR_NOPRIVS))
 			sendto_one_numeric(source_p, ERR_NOPRIVILEGES, form_str(ERR_NOPRIVILEGES));
@@ -1269,7 +1269,7 @@ chm_forward(struct Client *source_p, struct Channel *chptr,
 	if(!allow_mode_change(source_p, chptr, alevel, errors, c))
 		return;
 #else
-	if(!IsOper(source_p) && !IsServer(source_p))
+	if(!IsOperGeneral(source_p) && !IsServer(source_p))
 	{
 		if(!(*errors & SM_ERR_NOPRIVS))
 			sendto_one_numeric(source_p, ERR_NOPRIVILEGES, form_str(ERR_NOPRIVILEGES));

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -1742,7 +1742,13 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 
 	for(j = 0; j < 3; j++)
 	{
-		flags = flags_list[j];
+		int send_flags = flags = flags_list[j];
+		const char *priv = "";
+		if (flags == ONLY_OPERS)
+		{
+			send_flags = ALL_MEMBERS;
+			priv = "auspex:cmodes";
+		}
 		cur_len = mlen;
 		mbuf = modebuf + mlen;
 		pbuf = parabuf;
@@ -1775,8 +1781,8 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 				*mbuf = '\0';
 
 				if(cur_len > mlen)
-					sendto_channel_local(IsServer(source_p) ? fakesource_p : source_p,
-							flags, chptr, "%s %s", modebuf, parabuf);
+					sendto_channel_local_priv(IsServer(source_p) ? fakesource_p : source_p,
+							send_flags, priv, chptr, "%s %s", modebuf, parabuf);
 				else
 					continue;
 
@@ -1812,8 +1818,8 @@ set_channel_mode(struct Client *client_p, struct Client *source_p,
 
 		*mbuf = '\0';
 		if(cur_len > mlen)
-			sendto_channel_local(IsServer(source_p) ? fakesource_p : source_p,
-				flags, chptr, "%s %s", modebuf, parabuf);
+			sendto_channel_local_priv(IsServer(source_p) ? fakesource_p : source_p,
+				send_flags, priv, chptr, "%s %s", modebuf, parabuf);
 	}
 
 	/* only propagate modes originating locally, or if we're hubbing */

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -714,17 +714,14 @@ chm_staff(struct Client *source_p, struct Channel *chptr,
 		*errors |= SM_ERR_NOPRIVS;
 		return;
 	}
-	if(MyClient(source_p) && !IsOperResv(source_p))
+	if(MyClient(source_p) && !HasPrivilege(source_p, "oper:cmodes"))
 	{
 		if(!(*errors & SM_ERR_NOPRIVS))
 			sendto_one(source_p, form_str(ERR_NOPRIVS), me.name,
-					source_p->name, "resv");
+					source_p->name, "cmodes");
 		*errors |= SM_ERR_NOPRIVS;
 		return;
 	}
-
-	if(!allow_mode_change(source_p, chptr, CHFL_CHANOP, errors, c))
-		return;
 
 	if(MyClient(source_p) && (++mode_limit_simple > MAXMODES_SIMPLE))
 		return;

--- a/ircd/chmode.c
+++ b/ircd/chmode.c
@@ -660,7 +660,7 @@ chm_hidden(struct Client *source_p, struct Channel *chptr,
 	  int alevel, int parc, int *parn,
 	  const char **parv, int *errors, int dir, char c, long mode_type)
 {
-	if(!IsOperGeneral(source_p) && !IsServer(source_p))
+	if(MyClient(source_p) && !IsOperGeneral(source_p))
 	{
 		if(!(*errors & SM_ERR_NOPRIVS))
 			sendto_one_numeric(source_p, ERR_NOPRIVILEGES, form_str(ERR_NOPRIVILEGES));
@@ -707,7 +707,7 @@ chm_staff(struct Client *source_p, struct Channel *chptr,
 	  int alevel, int parc, int *parn,
 	  const char **parv, int *errors, int dir, char c, long mode_type)
 {
-	if(!IsOper(source_p) && !IsServer(source_p))
+	if(MyClient(source_p) && !IsOper(source_p))
 	{
 		if(!(*errors & SM_ERR_NOPRIVS))
 			sendto_one_numeric(source_p, ERR_NOPRIVILEGES, form_str(ERR_NOPRIVILEGES));

--- a/ircd/client.c
+++ b/ircd/client.c
@@ -1833,11 +1833,11 @@ show_ip(struct Client *source_p, struct Client *target_p)
 		 * to local opers.
 		 */
 		if(!ConfigFileEntry.hide_spoof_ips &&
-		   (source_p == NULL || MyOper(source_p)))
+		   (source_p == NULL || (MyConnect(source_p) && HasPrivilege(source_p, "auspex:hostname"))))
 			return 1;
 		return 0;
 	}
-	else if(IsDynSpoof(target_p) && (source_p != NULL && !IsOper(source_p)))
+	else if(IsDynSpoof(target_p) && (source_p != NULL && !HasPrivilege(source_p, "auspex:hostname")))
 		return 0;
 	else
 		return 1;

--- a/ircd/hostmask.c
+++ b/ircd/hostmask.c
@@ -26,6 +26,7 @@
 #include "stdinc.h"
 #include "ircd_defs.h"
 #include "s_conf.h"
+#include "s_newconf.h"
 #include "hostmask.h"
 #include "numeric.h"
 #include "send.h"
@@ -729,7 +730,7 @@ report_auth(struct Client *client_p)
 			{
 				aconf = arec->aconf;
 
-				if(!IsOper(client_p) && IsConfDoSpoofIp(aconf))
+				if(!IsOperGeneral(client_p) && IsConfDoSpoofIp(aconf))
 					continue;
 
 				get_printable_conf(aconf, &name, &host, &pass, &user, &port,

--- a/ircd/packet.c
+++ b/ircd/packet.c
@@ -32,6 +32,7 @@
 #include "hook.h"
 #include "send.h"
 #include "s_assert.h"
+#include "s_newconf.h"
 
 static char readBuf[READBUF_SIZE];
 static void client_dopacket(struct Client *client_p, char *buffer, size_t length);
@@ -108,7 +109,7 @@ parse_client_queued(struct Client *client_p)
 		/* allow opers 4 times the amount of messages as users. why 4?
 		 * why not. :) --fl_
 		 */
-		if(IsOper(client_p) && ConfigFileEntry.no_oper_flood)
+		if(IsOperGeneral(client_p) && ConfigFileEntry.no_oper_flood)
 			allow_read *= 4;
 		/*
 		 * Handle flood protection here - if we exceed our flood limit on
@@ -294,7 +295,7 @@ read_packet(rb_fde_t * F, void *data)
 		if(!IsAnyServer(client_p) &&
 		   (rb_linebuf_alloclen(&client_p->localClient->buf_recvq) > ConfigFileEntry.client_flood_max_lines))
 		{
-			if(!(ConfigFileEntry.no_oper_flood && IsOper(client_p)))
+			if(!(ConfigFileEntry.no_oper_flood && IsOperGeneral(client_p)))
 			{
 				exit_client(client_p, client_p, client_p, "Excess Flood");
 				return;

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1381,7 +1381,7 @@ get_printable_kline(struct Client *source_p, struct ConfItem *aconf,
 	*user = EmptyString(aconf->user) ? null : aconf->user;
 	*reason = get_user_ban_reason(aconf);
 
-	if(!IsOper(source_p))
+	if(!IsOperGeneral(source_p))
 		*oper_reason = NULL;
 	else
 	{

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1237,6 +1237,9 @@ user_mode(struct Client *client_p, struct Client *source_p, int parc, const char
 		source_p->umodes &= ~UMODE_ADMIN;
 	}
 
+	if(MyClient(source_p))
+		source_p->handler = IsOperGeneral(source_p) ? OPER_HANDLER : CLIENT_HANDLER;
+
 	/* let modules providing usermodes know that we've changed our usermode --nenolod */
 	hdata.client = source_p;
 	hdata.oldumodes = setflags;
@@ -1438,6 +1441,8 @@ oper_up(struct Client *source_p, struct oper_conf *oper_p)
 	hdata.oldumodes = old;
 	hdata.oldsnomask = oldsnomask;
 	call_hook(h_umode_changed, &hdata);
+
+	source_p->handler = IsOperGeneral(source_p) ? OPER_HANDLER : CLIENT_HANDLER;
 
 	sendto_realops_snomask(SNO_GENERAL, L_ALL,
 			     "%s (%s!%s@%s) is now an operator", oper_p->name, source_p->name,

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -1047,7 +1047,7 @@ user_mode(struct Client *client_p, struct Client *source_p, int parc, const char
 
 	if(source_p != target_p)
 	{
-		if (MyOper(source_p) && parc < 3)
+		if (HasPrivilege(source_p, "auspex:umodes") && parc < 3)
 			show_other_user_mode(source_p, target_p);
 		else
 			sendto_one(source_p, form_str(ERR_USERSDONTMATCH), me.name, source_p->name);

--- a/modules/core/m_ban.c
+++ b/modules/core/m_ban.c
@@ -64,7 +64,7 @@ m_ban(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 {
 	sendto_one_notice(source_p, ":The BAN command is not user-accessible.");
 	sendto_one_notice(source_p, ":To ban a user from a channel, see /QUOTE HELP CMODE");
-	if (IsOper(source_p))
+	if (IsOperGeneral(source_p))
 		sendto_one_notice(source_p, ":To ban a user from a server or from the network, see /QUOTE HELP KLINE");
 }
 

--- a/modules/core/m_join.c
+++ b/modules/core/m_join.c
@@ -209,7 +209,7 @@ m_join(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 			continue;
 		}
 
-		if(splitmode && !IsOper(source_p) && (*name != '&') &&
+		if(splitmode && !IsOperGeneral(source_p) && (*name != '&') &&
 		   ConfigChannel.no_join_on_split)
 		{
 			sendto_one(source_p, form_str(ERR_UNAVAILRESOURCE),
@@ -269,7 +269,7 @@ m_join(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 				continue;
 			}
 
-			if(splitmode && !IsOper(source_p) && (*name != '&') &&
+			if(splitmode && !IsOperGeneral(source_p) && (*name != '&') &&
 			   ConfigChannel.no_create_on_split)
 			{
 				sendto_one(source_p, form_str(ERR_UNAVAILRESOURCE),
@@ -320,7 +320,7 @@ m_join(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		chptr = chptr2;
 
 		if(flags == 0 &&
-				!IsOper(source_p) && !IsExemptSpambot(source_p))
+				!IsOperGeneral(source_p) && !IsExemptSpambot(source_p))
 			check_spambot_warning(source_p, name);
 
 		/* add the user to the channel */
@@ -966,7 +966,7 @@ do_join_0(struct Client *client_p, struct Client *source_p)
 	while((ptr = source_p->user->channel.head))
 	{
 		if(MyConnect(source_p) &&
-		   !IsOper(source_p) && !IsExemptSpambot(source_p))
+		   !IsOperGeneral(source_p) && !IsExemptSpambot(source_p))
 			check_spambot_warning(source_p, NULL);
 
 		msptr = ptr->data;
@@ -987,7 +987,7 @@ check_channel_name_loc(struct Client *source_p, const char *name)
 	if(EmptyString(name))
 		return false;
 
-	if(ConfigFileEntry.disable_fake_channels && !IsOper(source_p))
+	if(ConfigFileEntry.disable_fake_channels && !IsOperGeneral(source_p))
 	{
 		for(p = name; *p; ++p)
 		{

--- a/modules/core/m_message.c
+++ b/modules/core/m_message.c
@@ -513,7 +513,7 @@ msg_channel(enum message_type msgtype,
 	if((result = can_send(chptr, source_p, NULL)))
 	{
 		if(result != CAN_SEND_OPV && MyClient(source_p) &&
-		   !IsOper(source_p) &&
+		   !IsOperGeneral(source_p) &&
 		   !add_channel_target(source_p, chptr))
 		{
 			sendto_one(source_p, form_str(ERR_TARGCHANGE),
@@ -531,7 +531,7 @@ msg_channel(enum message_type msgtype,
 			(!(chptr->mode.mode & MODE_NOPRIVMSGS) ||
 			 IsMember(source_p, chptr)))
 	{
-		if(MyClient(source_p) && !IsOper(source_p) &&
+		if(MyClient(source_p) && !IsOperGeneral(source_p) &&
 		   !add_channel_target(source_p, chptr))
 		{
 			sendto_one(source_p, form_str(ERR_TARGCHANGE),
@@ -724,7 +724,7 @@ msg_client(enum message_type msgtype,
 			source_p->localClient->last = rb_current_time();
 
 		/* auto cprivmsg/cnotice */
-		do_floodcount = !IsOper(source_p) &&
+		do_floodcount = !IsOperGeneral(source_p) &&
 			!find_allowing_channel(source_p, target_p);
 
 		/* target change stuff, dont limit ctcp replies as that

--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -642,7 +642,7 @@ change_local_nick(struct Client *client_p, struct Client *source_p,
 		source_p->localClient->last_nick_change = rb_current_time();
 		source_p->localClient->number_of_nick_changes++;
 
-		if(ConfigFileEntry.anti_nick_flood && !IsOper(source_p) &&
+		if(ConfigFileEntry.anti_nick_flood && !IsOperGeneral(source_p) &&
 				source_p->localClient->number_of_nick_changes > ConfigFileEntry.max_nick_changes)
 		{
 			sendto_one(source_p, form_str(ERR_NICKTOOFAST),

--- a/modules/core/m_part.c
+++ b/modules/core/m_part.c
@@ -38,6 +38,7 @@
 #include "packet.h"
 #include "inline/stringops.h"
 #include "hook.h"
+#include "s_newconf.h"
 
 static const char part_desc[] = "Provides the PART command to leave a channel";
 
@@ -117,7 +118,7 @@ part_one_client(struct Client *client_p, struct Client *source_p, char *name, co
 		return;
 	}
 
-	if(MyConnect(source_p) && !IsOper(source_p) && !IsExemptSpambot(source_p))
+	if(MyConnect(source_p) && !IsOperGeneral(source_p) && !IsExemptSpambot(source_p))
 		check_spambot_warning(source_p, NULL);
 
 	/*

--- a/modules/core/m_quit.c
+++ b/modules/core/m_quit.c
@@ -33,6 +33,7 @@
 #include "modules.h"
 #include "s_conf.h"
 #include "inline/stringops.h"
+#include "s_newconf.h"
 
 static const char quit_desc[] = "Provides the QUIT command to allow a user to leave the network";
 
@@ -86,7 +87,7 @@ m_quit(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 		comment = reason;
 	}
 
-	if (comment == NULL || (!IsOper(source_p) && hdata.reason == hdata.orig_reason &&
+	if (comment == NULL || (!IsOperGeneral(source_p) && hdata.reason == hdata.orig_reason &&
 	   (source_p->localClient->firsttime + ConfigFileEntry.anti_spam_exit_message_time) >
 	   rb_current_time()))
 	{

--- a/modules/m_away.c
+++ b/modules/m_away.c
@@ -34,6 +34,7 @@
 #include "s_conf.h"
 #include "s_serv.h"
 #include "packet.h"
+#include "s_newconf.h"
 
 static const char away_desc[] = "Provides the AWAY command to set yourself away";
 
@@ -97,7 +98,7 @@ m_away(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p
 	/* Rate limit this because it is sent to common channels. */
 	if (MyClient(source_p))
 	{
-		if(!IsOper(source_p) &&
+		if(!IsOperGeneral(source_p) &&
 				source_p->localClient->next_away > rb_current_time())
 		{
 			sendto_one(source_p, form_str(RPL_LOAD2HI),

--- a/modules/m_info.c
+++ b/modules/m_info.c
@@ -37,6 +37,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "s_newconf.h"
 
 static const char info_desc[] =
 	"Provides the INFO command for retrieving server copyright, credits, and other info";
@@ -716,7 +717,7 @@ mo_info(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		info_spy(source_p);
 		send_info_text(source_p);
 
-		if(IsOper(source_p))
+		if(IsOperGeneral(source_p))
 		{
 			send_conf_options(source_p);
 			sendto_one_numeric(source_p, RPL_INFO, ":%s",

--- a/modules/m_invite.c
+++ b/modules/m_invite.c
@@ -37,6 +37,7 @@
 #include "modules.h"
 #include "packet.h"
 #include "tgchange.h"
+#include "s_newconf.h"
 
 static const char invite_desc[] = "Provides /invite";
 
@@ -176,7 +177,7 @@ m_invite(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	if(MyConnect(source_p))
 	{
-		if (ConfigFileEntry.target_change && !IsOper(source_p) &&
+		if (ConfigFileEntry.target_change && !IsOperGeneral(source_p) &&
 				!find_allowing_channel(source_p, target_p) &&
 				!add_target(source_p, target_p))
 		{

--- a/modules/m_knock.c
+++ b/modules/m_knock.c
@@ -35,6 +35,7 @@
 #include "modules.h"
 #include "s_serv.h"
 #include "supported.h"
+#include "s_newconf.h"
 
 static const char knock_desc[] = "Provides the KNOCK command to ask for an invite to an invite-only channel";
 
@@ -142,7 +143,7 @@ m_knock(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		 * allow one knock per user per knock_delay
 		 * allow one knock per channel per knock_delay_channel
 		 */
-		if(!IsOper(source_p) &&
+		if(!IsOperGeneral(source_p) &&
 		   (source_p->localClient->last_knock + ConfigChannel.knock_delay) > rb_current_time())
 		{
 			sendto_one(source_p, form_str(ERR_TOOMANYKNOCK),

--- a/modules/m_names.c
+++ b/modules/m_names.c
@@ -35,6 +35,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "s_newconf.h"
 
 static const char names_desc[] = "Provides the NAMES command to view users on a channel";
 
@@ -88,7 +89,7 @@ m_names(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	}
 	else
 	{
-		if(!IsOper(source_p))
+		if(!IsOperGeneral(source_p))
 		{
 			if((last_used + ConfigFileEntry.pace_wait) > rb_current_time())
 			{

--- a/modules/m_privs.c
+++ b/modules/m_privs.c
@@ -177,6 +177,13 @@ mo_privs(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		}
 	}
 
+	if (target_p != source_p && !HasPrivilege(source_p, "oper:privs"))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			   me.name, source_p->name, "privs");
+		return;
+	}
+
 	if (!IsServer(server_p))
 		server_p = server_p->servptr;
 

--- a/modules/m_services.c
+++ b/modules/m_services.c
@@ -334,7 +334,7 @@ h_svc_stats(hook_data_int *data)
 	char statchar = (char) data->arg2;
 	rb_dlink_node *ptr;
 
-	if (statchar == 'U' && IsOper(data->client))
+	if (statchar == 'U' && IsOperGeneral(data->client))
 	{
 		RB_DLINK_FOREACH(ptr, service_list.head)
 		{

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -789,7 +789,7 @@ stats_oper(struct Client *source_p)
 		sendto_one_numeric(source_p, RPL_STATSOLINE,
 				form_str(RPL_STATSOLINE),
 				oper_p->username, oper_p->host, oper_p->name,
-				IsOperGeneral(source_p) ? oper_p->privset->name : "0", "-1");
+				HasPrivilege(source_p, "oper:privs") ? oper_p->privset->name : "0", "-1");
 	}
 }
 
@@ -810,6 +810,13 @@ stats_capability(struct Client *client_p)
 static void
 stats_privset(struct Client *source_p)
 {
+	if (!HasPrivilege(source_p, "oper:privs"))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			   me.name, source_p->name, "privs");
+		return;
+	}
+
 	privilegeset_report(source_p);
 }
 

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -90,8 +90,8 @@ struct stats_cmd
 		handler_t handler;
 		handler_parv_t handler_parv;
 	};
+	const char *need_priv;
 	bool need_parv;
-	bool need_oper;
 	bool need_admin;
 };
 
@@ -132,10 +132,10 @@ static void stats_ziplinks(struct Client *);
 static void stats_comm(struct Client *);
 static void stats_capability(struct Client *);
 
-#define HANDLER_NORM(fn, oper, admin) \
-		{ { .handler = fn }, .need_parv = false, .need_oper = oper, .need_admin = admin }
-#define HANDLER_PARV(fn, oper, admin) \
-		{ { .handler_parv = fn }, .need_parv = true, .need_oper = oper, .need_admin = admin }
+#define HANDLER_NORM(fn, admin, priv) \
+		{ { .handler = fn }, .need_parv = false, .need_priv = priv, .need_admin = admin }
+#define HANDLER_PARV(fn, admin, priv) \
+		{ { .handler_parv = fn }, .need_parv = true, .need_priv = priv, .need_admin = admin }
 
 /* This table contains the possible stats items, in order:
  * stats letter,  function to call, operonly? adminonly? --fl_
@@ -145,54 +145,54 @@ static void stats_capability(struct Client *);
  * --Elizafox
  */
 static struct stats_cmd stats_cmd_table[256] = {
-/*	letter               handler		oper	admin	*/
-	['a'] = HANDLER_NORM(stats_dns_servers,	true,	true),
-	['A'] = HANDLER_NORM(stats_dns_servers,	true,	true),
-	['b'] = HANDLER_NORM(stats_delay,	true,	true),
-	['B'] = HANDLER_NORM(stats_hash,	true,	true),
-	['c'] = HANDLER_NORM(stats_connect,	false,	false),
-	['C'] = HANDLER_NORM(stats_capability,	true,	false),
-	['d'] = HANDLER_NORM(stats_tdeny,	true,	false),
-	['D'] = HANDLER_NORM(stats_deny,	true,	false),
-	['e'] = HANDLER_NORM(stats_exempt,	true,	false),
-	['E'] = HANDLER_NORM(stats_events,	true,	true),
-	['f'] = HANDLER_NORM(stats_comm,	true,	true),
-	['F'] = HANDLER_NORM(stats_comm,	true,	true),
-	['g'] = HANDLER_NORM(stats_prop_klines,	true,	false),
-	['h'] = HANDLER_NORM(stats_hubleaf,	false,	false),
-	['H'] = HANDLER_NORM(stats_hubleaf,	false,	false),
-	['i'] = HANDLER_NORM(stats_auth,	false,	false),
-	['I'] = HANDLER_NORM(stats_auth,	false,	false),
-	['k'] = HANDLER_NORM(stats_tklines,	false,	false),
-	['K'] = HANDLER_NORM(stats_klines,	false,	false),
-	['l'] = HANDLER_PARV(stats_ltrace,	false,	false),
-	['L'] = HANDLER_PARV(stats_ltrace,	false,	false),
-	['m'] = HANDLER_NORM(stats_messages,	false,	false),
-	['M'] = HANDLER_NORM(stats_messages,	false,	false),
-	['n'] = HANDLER_NORM(stats_dnsbl,	false,	false),
-	['o'] = HANDLER_NORM(stats_oper,	false,	false),
-	['O'] = HANDLER_NORM(stats_privset,	true,	false),
-	['p'] = HANDLER_NORM(stats_operedup,	false,	false),
-	['P'] = HANDLER_NORM(stats_ports,	false,	false),
-	['q'] = HANDLER_NORM(stats_tresv,	true,	false),
-	['Q'] = HANDLER_NORM(stats_resv,	true,	false),
-	['r'] = HANDLER_NORM(stats_usage,	true,	false),
-	['R'] = HANDLER_NORM(stats_usage,	true,	false),
-	['s'] = HANDLER_NORM(stats_ssld,	true,	true),
-	['S'] = HANDLER_NORM(stats_ssld,	true,	true),
-	['t'] = HANDLER_NORM(stats_tstats,	true,	false),
-	['T'] = HANDLER_NORM(stats_tstats,	true,	false),
-	['u'] = HANDLER_NORM(stats_uptime,	false,	false),
-	['U'] = HANDLER_NORM(stats_shared,	true,	false),
-	['v'] = HANDLER_NORM(stats_servers,	false,	false),
-	['V'] = HANDLER_NORM(stats_servers,	false,	false),
-	['x'] = HANDLER_NORM(stats_tgecos,	true,	false),
-	['X'] = HANDLER_NORM(stats_gecos,	true,	false),
-	['y'] = HANDLER_NORM(stats_class,	false,	false),
-	['Y'] = HANDLER_NORM(stats_class,	false,	false),
-	['z'] = HANDLER_NORM(stats_memory,	true,	false),
-	['Z'] = HANDLER_NORM(stats_ziplinks,	true,	false),
-	['?'] = HANDLER_NORM(stats_servlinks,	false,	false),
+/*	letter               handler		admin	priv */
+	['a'] = HANDLER_NORM(stats_dns_servers,	true,	NULL),
+	['A'] = HANDLER_NORM(stats_dns_servers,	true,	NULL),
+	['b'] = HANDLER_NORM(stats_delay,	true,	NULL),
+	['B'] = HANDLER_NORM(stats_hash,	true,	NULL),
+	['c'] = HANDLER_NORM(stats_connect,	false,	NULL),
+	['C'] = HANDLER_NORM(stats_capability,	false,	"oper:general"),
+	['d'] = HANDLER_NORM(stats_tdeny,	false,	"oper:general"),
+	['D'] = HANDLER_NORM(stats_deny,	false,	"oper:general"),
+	['e'] = HANDLER_NORM(stats_exempt,	false,	"oper:general"),
+	['E'] = HANDLER_NORM(stats_events,	true,	NULL),
+	['f'] = HANDLER_NORM(stats_comm,	true,	NULL),
+	['F'] = HANDLER_NORM(stats_comm,	true,	NULL),
+	['g'] = HANDLER_NORM(stats_prop_klines,	false,	"oper:general"),
+	['h'] = HANDLER_NORM(stats_hubleaf,	false,	NULL),
+	['H'] = HANDLER_NORM(stats_hubleaf,	false,	NULL),
+	['i'] = HANDLER_NORM(stats_auth,	false,	NULL),
+	['I'] = HANDLER_NORM(stats_auth,	false,	NULL),
+	['k'] = HANDLER_NORM(stats_tklines,	false,	NULL),
+	['K'] = HANDLER_NORM(stats_klines,	false,	NULL),
+	['l'] = HANDLER_PARV(stats_ltrace,	false,	NULL),
+	['L'] = HANDLER_PARV(stats_ltrace,	false,	NULL),
+	['m'] = HANDLER_NORM(stats_messages,	false,	NULL),
+	['M'] = HANDLER_NORM(stats_messages,	false,	NULL),
+	['n'] = HANDLER_NORM(stats_dnsbl,	false,	NULL),
+	['o'] = HANDLER_NORM(stats_oper,	false,	NULL),
+	['O'] = HANDLER_NORM(stats_privset,	false,	"oper:general"),
+	['p'] = HANDLER_NORM(stats_operedup,	false,	NULL),
+	['P'] = HANDLER_NORM(stats_ports,	false,	NULL),
+	['q'] = HANDLER_NORM(stats_tresv,	false,	"oper:general"),
+	['Q'] = HANDLER_NORM(stats_resv,	false,	"oper:general"),
+	['r'] = HANDLER_NORM(stats_usage,	false,	"oper:general"),
+	['R'] = HANDLER_NORM(stats_usage,	false,	"oper:general"),
+	['s'] = HANDLER_NORM(stats_ssld,	true,	NULL),
+	['S'] = HANDLER_NORM(stats_ssld,	true,	NULL),
+	['t'] = HANDLER_NORM(stats_tstats,	false,	"oper:general"),
+	['T'] = HANDLER_NORM(stats_tstats,	false,	"oper:general"),
+	['u'] = HANDLER_NORM(stats_uptime,	false,	NULL),
+	['U'] = HANDLER_NORM(stats_shared,	false,	"oper:general"),
+	['v'] = HANDLER_NORM(stats_servers,	false,	NULL),
+	['V'] = HANDLER_NORM(stats_servers,	false,	NULL),
+	['x'] = HANDLER_NORM(stats_tgecos,	false,	"oper:general"),
+	['X'] = HANDLER_NORM(stats_gecos,	false,	"oper:general"),
+	['y'] = HANDLER_NORM(stats_class,	false,	NULL),
+	['Y'] = HANDLER_NORM(stats_class,	false,	NULL),
+	['z'] = HANDLER_NORM(stats_memory,	false,	"oper:general"),
+	['Z'] = HANDLER_NORM(stats_ziplinks,	false,	"oper:general"),
+	['?'] = HANDLER_NORM(stats_servlinks,	false,	NULL),
 };
 
 /*
@@ -249,16 +249,26 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		/* Called for remote clients and for local opers, so check need_admin
 		 * and need_oper
 		 */
+		const char *missing_priv = NULL;
 		if(cmd->need_admin && !IsOperAdmin(source_p))
+			missing_priv = "admin";
+		else if(cmd->need_priv && !HasPrivilege(source_p, cmd->need_priv))
+			missing_priv = cmd->need_priv;
+
+		if(missing_priv != NULL)
 		{
-			sendto_one(source_p, form_str(ERR_NOPRIVS),
-				   me.name, source_p->name, "admin");
-			goto stats_out;
-		}
-		if(cmd->need_oper && !IsOperGeneral(source_p))
-		{
-			sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
-					   form_str (ERR_NOPRIVILEGES));
+			if(!IsOper(source_p))
+			{
+				sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
+					form_str(ERR_NOPRIVILEGES));
+			}
+			else
+			{
+				if(!strncmp(missing_priv, "oper:", 5))
+					missing_priv += 5;
+				sendto_one(source_p, form_str(ERR_NOPRIVS),
+					me.name, source_p->name, missing_priv);
+			}
 			goto stats_out;
 		}
 

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -246,9 +246,6 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	if(cmd->handler != NULL)
 	{
 		/* The stats table says what privs are needed, so check --fl_ */
-		/* Called for remote clients and for local opers, so check need_admin
-		 * and need_oper
-		 */
 		const char *missing_priv = NULL;
 		if(cmd->need_admin && !IsOperAdmin(source_p))
 			missing_priv = "admin";

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -212,7 +212,7 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 
 	statchar = parv[1][0];
 
-	if(MyClient(source_p) && !IsOper(source_p) && parc > 2)
+	if(MyClient(source_p) && !IsOperGeneral(source_p) && parc > 2)
 	{
 		/* Check the user is actually allowed to do /stats, and isnt flooding */
 		if((last_used + ConfigFileEntry.pace_wait) > rb_current_time())
@@ -253,7 +253,7 @@ m_stats(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 				   me.name, source_p->name, "admin");
 			goto stats_out;
 		}
-		if(cmd->need_oper && !IsOper(source_p))
+		if(cmd->need_oper && !IsOperGeneral(source_p))
 		{
 			sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 					   form_str (ERR_NOPRIVILEGES));
@@ -322,7 +322,7 @@ stats_connect(struct Client *source_p)
 
 	if((ConfigFileEntry.stats_c_oper_only ||
 	    (ConfigServerHide.flatten_links && !IsExemptShide(source_p))) &&
-	    !IsOper(source_p))
+	    !IsOperGeneral(source_p))
 	{
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str(ERR_NOPRIVILEGES));
@@ -338,7 +338,7 @@ stats_connect(struct Client *source_p)
 
 		s = buf;
 
-		if(IsOper(source_p))
+		if(IsOperGeneral(source_p))
 		{
 			if(ServerConfAutoconn(server_p))
 				*s++ = 'A';
@@ -527,7 +527,7 @@ stats_hubleaf(struct Client *source_p)
 
 	if((ConfigFileEntry.stats_h_oper_only ||
 	    (ConfigServerHide.flatten_links && !IsExemptShide(source_p))) &&
-	    !IsOper(source_p))
+	    !IsOperGeneral(source_p))
 	{
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
@@ -554,12 +554,12 @@ static void
 stats_auth (struct Client *source_p)
 {
 	/* Oper only, if unopered, return ERR_NOPRIVS */
-	if((ConfigFileEntry.stats_i_oper_only == 2) && !IsOper (source_p))
+	if((ConfigFileEntry.stats_i_oper_only == 2) && !IsOperGeneral (source_p))
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
 
 	/* If unopered, Only return matching auth blocks */
-	else if((ConfigFileEntry.stats_i_oper_only == 1) && !IsOper (source_p))
+	else if((ConfigFileEntry.stats_i_oper_only == 1) && !IsOperGeneral (source_p))
 	{
 		struct ConfItem *aconf;
 		char *name, *host, *user, *classname;
@@ -598,12 +598,12 @@ static void
 stats_tklines(struct Client *source_p)
 {
 	/* Oper only, if unopered, return ERR_NOPRIVS */
-	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOper (source_p))
+	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOperGeneral (source_p))
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
 
 	/* If unopered, Only return matching klines */
-	else if((ConfigFileEntry.stats_k_oper_only == 1) && !IsOper (source_p))
+	else if((ConfigFileEntry.stats_k_oper_only == 1) && !IsOperGeneral (source_p))
 	{
 		struct ConfItem *aconf;
 		char *host, *pass, *user, *oper_reason;
@@ -700,12 +700,12 @@ static void
 stats_klines(struct Client *source_p)
 {
 	/* Oper only, if unopered, return ERR_NOPRIVS */
-	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOper (source_p))
+	if((ConfigFileEntry.stats_k_oper_only == 2) && !IsOperGeneral (source_p))
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
 
 	/* If unopered, Only return matching klines */
-	else if((ConfigFileEntry.stats_k_oper_only == 1) && !IsOper (source_p))
+	else if((ConfigFileEntry.stats_k_oper_only == 1) && !IsOperGeneral (source_p))
 	{
 		struct ConfItem *aconf;
 		char *host, *pass, *user, *oper_reason;
@@ -775,7 +775,7 @@ stats_oper(struct Client *source_p)
 	struct oper_conf *oper_p;
 	rb_dlink_node *ptr;
 
-	if(!IsOper(source_p) && ConfigFileEntry.stats_o_oper_only)
+	if(!IsOperGeneral(source_p) && ConfigFileEntry.stats_o_oper_only)
 	{
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
@@ -789,7 +789,7 @@ stats_oper(struct Client *source_p)
 		sendto_one_numeric(source_p, RPL_STATSOLINE,
 				form_str(RPL_STATSOLINE),
 				oper_p->username, oper_p->host, oper_p->name,
-				IsOper(source_p) ? oper_p->privset->name : "0", "-1");
+				IsOperGeneral(source_p) ? oper_p->privset->name : "0", "-1");
 	}
 }
 
@@ -853,7 +853,7 @@ stats_operedup (struct Client *source_p)
 static void
 stats_ports (struct Client *source_p)
 {
-	if(!IsOper (source_p) && ConfigFileEntry.stats_P_oper_only)
+	if(!IsOperGeneral (source_p) && ConfigFileEntry.stats_P_oper_only)
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
 	else
@@ -1181,7 +1181,7 @@ stats_servers (struct Client *source_p)
 	int days, hours, minutes;
 	int j = 0;
 
-	if(ConfigServerHide.flatten_links && !IsOper(source_p) &&
+	if(ConfigServerHide.flatten_links && !IsOperGeneral(source_p) &&
 	   !IsExemptShide(source_p))
 	{
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
@@ -1257,7 +1257,7 @@ stats_gecos(struct Client *source_p)
 static void
 stats_class(struct Client *source_p)
 {
-	if(ConfigFileEntry.stats_y_oper_only && !IsOper(source_p))
+	if(ConfigFileEntry.stats_y_oper_only && !IsOperGeneral(source_p))
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
 				   form_str (ERR_NOPRIVILEGES));
 	else
@@ -1524,7 +1524,7 @@ stats_servlinks (struct Client *source_p)
 	int j = 0;
 	char buf[128];
 
-	if(ConfigServerHide.flatten_links && !IsOper (source_p) &&
+	if(ConfigServerHide.flatten_links && !IsOperGeneral (source_p) &&
 	   !IsExemptShide(source_p))
 	{
 		sendto_one_numeric(source_p, ERR_NOPRIVILEGES,
@@ -1553,7 +1553,7 @@ stats_servlinks (struct Client *source_p)
 			rb_current_time() - target_p->localClient->firsttime,
 			(rb_current_time() > target_p->localClient->lasttime) ?
 			 (rb_current_time() - target_p->localClient->lasttime) : 0,
-			IsOper (source_p) ? show_capabilities (target_p) : "TS");
+			IsOperGeneral (source_p) ? show_capabilities (target_p) : "TS");
 	}
 
 	sendto_one_numeric(source_p, RPL_STATSDEBUG,
@@ -1659,7 +1659,7 @@ stats_ltrace(struct Client *source_p, int parc, const char *parv[])
 			stats_l_list(source_p, name, doall, wilds, &local_oper_list, statchar, stats_l_should_show_oper);
 		}
 
-		if (!ConfigServerHide.flatten_links || IsOper(source_p) ||
+		if (!ConfigServerHide.flatten_links || IsOperGeneral(source_p) ||
 				IsExemptShide(source_p))
 			stats_l_list(source_p, name, doall, wilds, &serv_list, statchar, NULL);
 
@@ -1713,7 +1713,7 @@ stats_l_client(struct Client *source_p, struct Client *target_p,
 				rb_current_time() - target_p->localClient->firsttime,
 				(rb_current_time() > target_p->localClient->lasttime) ?
 				 (rb_current_time() - target_p->localClient->lasttime) : 0,
-				IsOper(source_p) ? show_capabilities(target_p) : "-");
+				IsOperGeneral(source_p) ? show_capabilities(target_p) : "-");
 	}
 
 	else

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -132,8 +132,10 @@ static void stats_ziplinks(struct Client *);
 static void stats_comm(struct Client *);
 static void stats_capability(struct Client *);
 
-#define HANDLER_NORM(fn, oper, admin) { { .handler = fn }, false, oper, admin }
-#define HANDLER_PARV(fn, oper, admin) { { .handler_parv = fn }, true, oper, admin }
+#define HANDLER_NORM(fn, oper, admin) \
+		{ { .handler = fn }, .need_parv = false, .need_oper = oper, .need_admin = admin }
+#define HANDLER_PARV(fn, oper, admin) \
+		{ { .handler_parv = fn }, .need_parv = true, .need_oper = oper, .need_admin = admin }
 
 /* This table contains the possible stats items, in order:
  * stats letter,  function to call, operonly? adminonly? --fl_

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -171,7 +171,7 @@ static struct stats_cmd stats_cmd_table[256] = {
 	['M'] = HANDLER_NORM(stats_messages,	false,	NULL),
 	['n'] = HANDLER_NORM(stats_dnsbl,	false,	NULL),
 	['o'] = HANDLER_NORM(stats_oper,	false,	NULL),
-	['O'] = HANDLER_NORM(stats_privset,	false,	"oper:general"),
+	['O'] = HANDLER_NORM(stats_privset,	false,	"oper:privs"),
 	['p'] = HANDLER_NORM(stats_operedup,	false,	NULL),
 	['P'] = HANDLER_NORM(stats_ports,	false,	NULL),
 	['q'] = HANDLER_NORM(stats_tresv,	false,	"oper:general"),
@@ -822,13 +822,6 @@ stats_capability(struct Client *client_p)
 static void
 stats_privset(struct Client *source_p)
 {
-	if (!HasPrivilege(source_p, "oper:privs"))
-	{
-		sendto_one(source_p, form_str(ERR_NOPRIVS),
-			   me.name, source_p->name, "privs");
-		return;
-	}
-
 	privilegeset_report(source_p);
 }
 

--- a/modules/m_testline.c
+++ b/modules/m_testline.c
@@ -75,6 +75,13 @@ mo_testline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sou
 	char *puser, *phost, *reason, *operreason;
 	char reasonbuf[BUFSIZE];
 
+	if (!HasPrivilege(source_p, "oper:testline"))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			   me.name, source_p->name, "testline");
+		return;
+	}
+
 	mask = LOCAL_COPY(parv[1]);
 
 	if (IsChannelName(mask))
@@ -230,6 +237,13 @@ static void
 mo_testgecos(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p, int parc, const char *parv[])
 {
 	struct ConfItem *aconf;
+
+	if (!HasPrivilege(source_p, "oper:testline"))
+	{
+		sendto_one(source_p, form_str(ERR_NOPRIVS),
+			   me.name, source_p->name, "testline");
+		return;
+	}
 
 	if(!(aconf = find_xline(parv[1], 0)))
 	{

--- a/modules/m_topic.c
+++ b/modules/m_topic.c
@@ -112,7 +112,7 @@ m_topic(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 		}
 
 		if(MyClient(source_p) && !is_chanop_voiced(msptr) &&
-				!IsOper(source_p) &&
+				!IsOperGeneral(source_p) &&
 				!add_channel_target(source_p, chptr))
 		{
 			sendto_one(source_p, form_str(ERR_TARGCHANGE),

--- a/modules/m_trace.c
+++ b/modules/m_trace.c
@@ -125,7 +125,7 @@ m_trace(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			/* giving this out with flattened links defeats the
 			 * object --fl
 			 */
-			if(IsOper(source_p) || IsExemptShide(source_p) ||
+			if(IsOperGeneral(source_p) || IsExemptShide(source_p) ||
 			   !ConfigServerHide.flatten_links)
 				sendto_one_numeric(source_p, RPL_TRACELINK,
 						   form_str(RPL_TRACELINK),

--- a/modules/m_who.c
+++ b/modules/m_who.c
@@ -192,7 +192,7 @@ m_who(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 
 		if(chptr != NULL)
 		{
-			if (!IsOper(source_p) && !ratelimit_client_who(source_p, rb_dlink_list_length(&chptr->members)/50))
+			if (!IsOperGeneral(source_p) && !ratelimit_client_who(source_p, rb_dlink_list_length(&chptr->members)/50))
 			{
 				sendto_one(source_p, form_str(RPL_LOAD2HI),
 						me.name, source_p->name, "WHO");
@@ -254,7 +254,7 @@ m_who(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_p,
 		flood_endgrace(source_p);
 
 	/* it has to be a global who at this point, limit it */
-	if(!IsOper(source_p))
+	if(!IsOperGeneral(source_p))
 	{
 		if((last_used + ConfigFileEntry.pace_wait) > rb_current_time() || !ratelimit_client(source_p, 1))
 		{
@@ -324,7 +324,7 @@ who_common_channel(struct Client *source_p, struct Channel *chptr,
 			if((mask == NULL) ||
 					match(mask, target_p->name) || match(mask, target_p->username) ||
 					match(mask, target_p->host) || match(mask, target_p->servptr->name) ||
-					(IsOper(source_p) && match(mask, target_p->orighost)) ||
+					(IsOperGeneral(source_p) && match(mask, target_p->orighost)) ||
 					match(mask, target_p->info))
 			{
 				do_who(source_p, target_p, NULL, fmt);
@@ -395,7 +395,7 @@ who_global(struct Client *source_p, const char *mask, int server_oper, int opers
 			if(!mask ||
 					match(mask, target_p->name) || match(mask, target_p->username) ||
 					match(mask, target_p->host) || match(mask, target_p->servptr->name) ||
-					(IsOper(source_p) && match(mask, target_p->orighost)) ||
+					(IsOperGeneral(source_p) && match(mask, target_p->orighost)) ||
 					match(mask, target_p->info))
 			{
 				do_who(source_p, target_p, NULL, fmt);
@@ -495,7 +495,7 @@ do_who(struct Client *source_p, struct Client *target_p, struct membership *mspt
 			   source_p->name, msptr ? msptr->chptr->chname : "*",
 			   target_p->username, target_p->host,
 			   target_p->servptr->name, target_p->name, status,
-			   ConfigServerHide.flatten_links && !IsOper(source_p) && !IsExemptShide(source_p) ? 0 : target_p->hopcount,
+			   ConfigServerHide.flatten_links && !IsOperGeneral(source_p) && !IsExemptShide(source_p) ? 0 : target_p->hopcount,
 			   target_p->info);
 	else
 	{
@@ -525,7 +525,7 @@ do_who(struct Client *source_p, struct Client *target_p, struct membership *mspt
 		if (fmt->fields & FIELD_FLAGS)
 			append_format(str, sizeof str, &pos, " %s", status);
 		if (fmt->fields & FIELD_HOP)
-			append_format(str, sizeof str, &pos, " %d", ConfigServerHide.flatten_links && !IsOper(source_p) && !IsExemptShide(source_p) ? 0 : target_p->hopcount);
+			append_format(str, sizeof str, &pos, " %d", ConfigServerHide.flatten_links && !IsOperGeneral(source_p) && !IsExemptShide(source_p) ? 0 : target_p->hopcount);
 		if (fmt->fields & FIELD_IDLE)
 			append_format(str, sizeof str, &pos, " %d", (int)(MyClient(target_p) ? rb_current_time() - target_p->localClient->last : 0));
 		if (fmt->fields & FIELD_ACCOUNT)

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -349,7 +349,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 
 	if(MyClient(target_p))
 	{
-		if (IsDynSpoof(target_p) && (IsOperGeneral(source_p) || source_p == target_p))
+		if (IsDynSpoof(target_p) && (HasPrivilege(source_p, "auspex:hostname") || source_p == target_p))
 		{
 			/* trick here: show a nonoper their own IP if
 			 * dynamic spoofed but not if auth{} spoofed
@@ -385,7 +385,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 	}
 	else
 	{
-		if (IsDynSpoof(target_p) && (IsOper(source_p) || source_p == target_p))
+		if (IsDynSpoof(target_p) && (HasPrivilege(source_p, "auspex:hostname") || source_p == target_p))
 		{
 			ClearDynSpoof(target_p);
 			sendto_one_numeric(source_p, RPL_WHOISHOST,

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -318,7 +318,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 				    GlobalSetOptions.operstring));
 	}
 
-	if(!EmptyString(target_p->user->opername) && IsOper(target_p) && IsOper(source_p))
+	if(!EmptyString(target_p->user->opername) && IsOper(target_p) && (target_p == source_p || HasPrivilege(source_p, "oper:privs")))
 	{
 		char buf[512];
 		const char *privset = "(missing)";

--- a/modules/m_whois.c
+++ b/modules/m_whois.c
@@ -89,7 +89,7 @@ m_whois(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 			return;
 		}
 
-		if(!IsOper(source_p))
+		if(!IsOperGeneral(source_p))
 		{
 			/* seeing as this is going across servers, we should limit it */
 			if((last_used + ConfigFileEntry.pace_wait_simple) > rb_current_time() || !ratelimit_client(source_p, 2))
@@ -340,7 +340,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 
 		sendto_one_numeric(source_p, RPL_WHOISSECURE, form_str(RPL_WHOISSECURE),
 				   target_p->name, cbuf);
-		if((source_p == target_p || IsOper(source_p)) &&
+		if((source_p == target_p || IsOperGeneral(source_p)) &&
 				target_p->certfp != NULL)
 			sendto_one_numeric(source_p, RPL_WHOISCERTFP,
 					form_str(RPL_WHOISCERTFP),
@@ -349,7 +349,7 @@ single_whois(struct Client *source_p, struct Client *target_p, int operspy)
 
 	if(MyClient(target_p))
 	{
-		if (IsDynSpoof(target_p) && (IsOper(source_p) || source_p == target_p))
+		if (IsDynSpoof(target_p) && (IsOperGeneral(source_p) || source_p == target_p))
 		{
 			/* trick here: show a nonoper their own IP if
 			 * dynamic spoofed but not if auth{} spoofed

--- a/modules/m_whowas.c
+++ b/modules/m_whowas.c
@@ -37,6 +37,7 @@
 #include "msg.h"
 #include "parse.h"
 #include "modules.h"
+#include "s_newconf.h"
 
 static const char whowas_desc[] =
 	"Provides the WHOWAS command to display information on a disconnected user";
@@ -70,7 +71,7 @@ m_whowas(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 
 	static time_t last_used = 0L;
 
-	if(MyClient(source_p) && !IsOper(source_p))
+	if(MyClient(source_p) && !IsOperGeneral(source_p))
 	{
 		if(last_used + (parc > 3 ? ConfigFileEntry.pace_wait :
 						ConfigFileEntry.pace_wait_simple

--- a/modules/um_callerid.c
+++ b/modules/um_callerid.c
@@ -118,7 +118,7 @@ allow_message(struct Client *source_p, struct Client *target_p)
 		return true;
 
 	/* XXX: controversial?  allow opers to send through +g */
-	if (IsOper(source_p))
+	if (IsOperGeneral(source_p))
 		return true;
 
 	if (accept_message(source_p, target_p))
@@ -168,7 +168,7 @@ add_callerid_accept_for_source(enum message_type msgtype, struct Client *source_
 	if(msgtype != MESSAGE_TYPE_NOTICE &&
 		IsSetAnyCallerID(source_p) &&
 		!accept_message(target_p, source_p) &&
-		!IsOper(target_p))
+		!IsOperGeneral(target_p))
 	{
 		if(rb_dlink_list_length(&source_p->localClient->allow_list) <
 				(unsigned long)ConfigFileEntry.max_accept)

--- a/tests/client_util.c
+++ b/tests/client_util.c
@@ -98,6 +98,8 @@ void make_local_person_oper(struct Client *client)
 	rb_dlinkAddAlloc(client, &local_oper_list);
 	rb_dlinkAddAlloc(client, &oper_list);
 	SetOper(client);
+	struct PrivilegeSet *p = privilegeset_set_new("test", "test:test", 0);
+	client->user->privset = privilegeset_ref(p);
 }
 
 void remove_local_person(struct Client *client)

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -1574,7 +1574,7 @@ static void sendto_channel_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local(user, ONLY_OPERS, channel, "Hello %s!", "World");
+	sendto_channel_local_priv(user, ALL_MEMBERS, "test:test", channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not an oper; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not an oper; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not an oper; " MSG);
@@ -1603,7 +1603,7 @@ static void sendto_channel_local1(void)
 	is_client_sendq_empty(server2, MSG);
 	is_client_sendq_empty(server3, MSG);
 
-	sendto_channel_local(user, ONLY_OPERS, lchannel, "Hello %s!", "World");
+	sendto_channel_local_priv(user, ALL_MEMBERS, "test:test", lchannel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not an oper; " MSG);
 	is_client_sendq("Hello World!" CRLF, oper1, "Is an oper; " MSG);
 	is_client_sendq("Hello World!" CRLF, oper2, "Is an oper; " MSG);
@@ -1664,7 +1664,7 @@ static void sendto_channel_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local(user, ONLY_OPERS, channel, "Hello %s!", "World");
+	sendto_channel_local_priv(user, ALL_MEMBERS, "test:test", channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not an oper; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not an oper; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not an oper; " MSG);
@@ -1696,7 +1696,7 @@ static void sendto_channel_local1__tags(void)
 	is_client_sendq_empty(server2, MSG);
 	is_client_sendq_empty(server3, MSG);
 
-	sendto_channel_local(user, ONLY_OPERS, lchannel, "Hello %s!", "World");
+	sendto_channel_local_priv(user, ALL_MEMBERS, "test:test", lchannel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not an oper; " MSG);
 	is_client_sendq("@account=test Hello World!" CRLF, oper1, "Is an oper; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, oper2, "Is an oper; " MSG);
@@ -1715,7 +1715,7 @@ static void sendto_channel_local1__tags(void)
 	is_client_sendq_empty(server2, MSG);
 	is_client_sendq_empty(server3, MSG);
 
-	sendto_channel_local(user, ONLY_OPERS, lchannel, "Hello %s!", "World");
+	sendto_channel_local_priv(user, ALL_MEMBERS, "test:test", lchannel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not an oper; " MSG);
 	is_client_sendq("Hello World!" CRLF, oper1, "Is an oper; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, oper2, "Is an oper; " MSG);


### PR DESCRIPTION
Separate lots of conceptually distinct oper functions into their own privs.

It's inconvenient that you need all +o's remaining bundled stuff in order to have any of these. To mitigate this, most such stuff has been moved into `oper:general`. A few things like being seen as an oper and seeing oper-only things remain in +o,