### PR TITLE
Recheck umodes for opers after rehash

### DIFF
--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -25,6 +25,7 @@
 #include "stdinc.h"
 #include "ircd_defs.h"
 #include "s_conf.h"
+#include "s_user.h"
 #include "s_newconf.h"
 #include "newconf.h"
 #include "s_serv.h"
@@ -630,6 +631,8 @@ attach_conf(struct Client *client_p, struct ConfItem *aconf)
 bool
 rehash(bool sig)
 {
+	rb_dlink_node *n;
+
 	hook_data_rehash hdata = { sig };
 
 	if(sig)
@@ -647,6 +650,16 @@ rehash(bool sig)
 		rb_strlcpy(me.info, "unknown", sizeof(me.info));
 
 	open_logfiles();
+
+	RB_DLINK_FOREACH(n, local_oper_list.head)
+	{
+		struct Client *oper = n->data;
+		const char *modeparv[4];
+		modeparv[0] = modeparv[1] = oper->name;
+		modeparv[2] = "+";
+		modeparv[3] = NULL;
+		user_mode(oper, oper, 3, modeparv);
+	}
 
 	call_hook(h_rehash, &hdata);
 	return false;


### PR DESCRIPTION
Currently if you gain or lose privileges due to a rehash your umodes won't update to reflect that, potentially leaving you with `a`, `p`, `H` etc. when you shouldn't have them (or not adding ones you should have) until you or someone else changes your mode (you can trigger this with `/mode $nick +`). Fix this the same way as for `/grant`, by calling `user_mode()` with noop arguments so it and any hooks get a chance to do things.