### PR TITLE
m_webirc: improve TLS handling

### DIFF
--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -129,10 +129,10 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 
 	if (parc >= 6)
 	{
-		char *s;
-		for (s = strtok(parv[5], " "); s != NULL; s = strtok(NULL, " "))
+		const char *s;
+		for (s = parv[5]; s != NULL; (s = strchr(s, ' ')) && s++)
 		{
-			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == '\0'))
+			if (!ircncmp(s, "secure", 6) && (s[6] == '=' || s[6] == ' ' || s[6] == '\0'))
 				secure = 1;
 		}
 	}

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -102,7 +102,7 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	}
 	if (!IsSSL(source_p) && aconf->flags & CONF_FLAGS_NEED_SSL)
 	{
-		sendto_one(source_p, "NOTICE * :Your CGI:IRC block requires SSL");
+		sendto_one(source_p, "NOTICE * :Your CGI:IRC block requires TLS");
 		return;
 	}
 

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -140,7 +140,7 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 	if (secure && !IsSSL(source_p))
 	{
 		sendto_one(source_p, "NOTICE * :CGI:IRC is not connected securely; marking you as insecure");
-		return 0;
+		secure = 0;
 	}
 
 	if (!secure)

--- a/extensions/m_webirc.c
+++ b/extensions/m_webirc.c
@@ -98,6 +98,11 @@ mr_webirc(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *sourc
 		sendto_one(source_p, "NOTICE * :CGI:IRC auth blocks must have a password");
 		return;
 	}
+	if (!IsSSL(source_p) && aconf->flags & CONF_FLAGS_NEED_SSL)
+	{
+		sendto_one(source_p, "NOTICE * :Your CGI:IRC block requires SSL");
+		return;
+	}
 
 	if (EmptyString(parv[1]))
 		encr = "";

--- a/include/client.h
+++ b/include/client.h
@@ -439,6 +439,7 @@ struct ListClient
 #define LFLAGS_FLUSH		0x00000002
 #define LFLAGS_CORK		0x00000004
 #define LFLAGS_SCTP		0x00000008
+#define LFLAGS_INSECURE	0x00000010	/* for marking SSL clients as insecure before registration */
 
 /* umodes, settable flags */
 /* lots of this moved to snomask -- jilles */
@@ -512,6 +513,10 @@ struct ListClient
 #define IsSCTP(x)		((x)->localClient->localflags & LFLAGS_SCTP)
 #define SetSCTP(x)		((x)->localClient->localflags |= LFLAGS_SCTP)
 #define ClearSCTP(x)		((x)->localClient->localflags &= ~LFLAGS_SCTP)
+
+#define IsInsecure(x)		((x)->localClient->localflags & LFLAGS_INSECURE)
+#define SetInsecure(x)		((x)->localClient->localflags |= LFLAGS_INSECURE)
+#define ClearInsecure(x)	((x)->localClient->localflags &= ~LFLAGS_INSECURE)
 
 /* oper flags */
 #define MyOper(x)               (MyConnect(x) && IsOper(x))

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -632,7 +632,7 @@ register_local_user(struct Client *client_p, struct Client *source_p)
 		add_to_id_hash(source_p->id, source_p);
 	}
 
-	if (IsSSL(source_p))
+	if (IsSSL(source_p) && !IsInsecure(source_p))
 		source_p->umodes |= UMODE_SSLCLIENT;
 
 	if (source_p->umodes & UMODE_INVISIBLE)


### PR DESCRIPTION
Enforce `need_ssl` if present on the webirc auth block.

Allow the client to gain +Z upon registration only if the WEBIRC message comes with the `secure` option from IRCv3. If the option is present but the connection is plaintext, send a helpful warning.

This could be seen as a regression, since web IRC gateways that don't send `secure` can't get +Z any more. I think this is technically correct—there was no way for such gateways to distinguish TLS connections, so we should assume the scarier possibility—but I'm happy to do something if there are sensible configurations that rely on the existing behaviour.