### PR TITLE
AIX/PASE support.

### DIFF
--- a/librb/src/crypt.c
+++ b/librb/src/crypt.c
@@ -777,6 +777,12 @@ static void   MD5Final (unsigned char [16], MD5_CTX *);
  * a multiple of 4.
  */
 
+#ifdef _AIX
+/* AIX lacks the endian.h header, so reimplement. AIX is always BE. */
+#define htole32(x) __builtin_bswap32(x)
+#define le32toh(x) __builtin_bswap32(x)
+#endif
+
 static void
 Encode (unsigned char *output, uint32_t *input, unsigned int len)
 {

--- a/librb/src/unix.c
+++ b/librb/src/unix.c
@@ -45,7 +45,8 @@
 #include <sys/sysctl.h>
 #endif
 
-#if defined(HAVE_SPAWN_H) && defined(HAVE_POSIX_SPAWN)
+/* it dies violently in PASE due to posix_spawnattr_init calling the unimplemented */
+#if defined(HAVE_SPAWN_H) && defined(HAVE_POSIX_SPAWN) && !defined(_AIX)
 #include <spawn.h>
 
 #ifndef __APPLE__


### PR DESCRIPTION
Actually, just PASE. librb dies horrible flaming deaths on AIX, but
bizarrely not PASE. It's like a program that only works in WSL. Go
figure.

To do this:
    - disable posix_spawn because it calls an unimplement syscall
      in PASE, bad juju
    - implement bare minimum of endianness macros, since AIX lacks
      though. only tested on gcc.

This commit was brought to you by a *dare*.