### PR TITLE
m_modules: make modreload work like restart

### DIFF
--- a/include/modules.h
+++ b/include/modules.h
@@ -28,6 +28,7 @@
 #include "defaults.h"
 #include "setup.h"
 #include "parse.h"
+#include "client.h" /* for IDLEN */
 
 #define MAPI_CHARYBDIS 2
 
@@ -117,6 +118,12 @@ struct mapi_mheader_av2
 
 #define DECLARE_MODULE_AV2(name, reg, unreg, cl, hl, hfnlist, caplist, v, desc) \
 	struct mapi_mheader_av2 _mheader = { MAPI_V2, reg, unreg, cl, hl, hfnlist, caplist, v, desc, DATECODE}
+
+struct modreload
+{
+	char module[BUFSIZE];
+	char id[IDLEN];
+};
 
 /* add a path */
 void mod_add_path(const char *path);


### PR DESCRIPTION
/modrestart used to be implemented as a normal command and could crash
when used remotely because it would reload m_encap, which was on the
call stack at the time. This was fixed in 41390bfe5f. However,
/modreload has exactly the same problem, so I'm giving it the
same treatment.

Incidentally: This bug was first discovered in ircd-seven, where the
`/mod*` commands themselves live in the core, so m_encap was the only way
the crash could happen (and it didn't most of the time, because m_encap
would only be moved if you got unlucky). But `/mod*` are in modules in
charybdis, so /modrestart would have unloaded the code it was in the
middle of executing. With that in mind, I'm not sure how it ever
appeared to work. It reliably crashes for me.