### PR TITLE
Set EXTERNAL_BUILD_TIMESTAMP from SOURCE_DATE_EPOCH

### DIFF
--- a/ircd/version.c.SH
+++ b/ircd/version.c.SH
@@ -15,6 +15,9 @@ fi
 
 generation=`expr $generation + 1`
 
+if test -n "$SOURCE_DATE_EPOCH" -a "$EXTERNAL_BUILD_TIMESTAMP" = '' ; then
+    EXTERNAL_BUILD_TIMESTAMP=$SOURCE_DATE_EPOCH
+fi
 if test "$EXTERNAL_BUILD_TIMESTAMP" = ''; then
     creation=`LC_ALL=C date | \
 awk '{if (NF == 6) \


### PR DESCRIPTION
Set `EXTERNAL_BUILD_TIMESTAMP` from `SOURCE_DATE_EPOCH`
to make the package build reproducible by default without
everyone having to discover the custom variable.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This code assigns the plain integer to keep the code simple.
Otherwise we would have to deal with differences between GNU date
and BSD date or include extra build deps like perl or python.