### PR TITLE
Remember and send reasons for rejectcache rejections

### DIFF
--- a/include/reject.h
+++ b/include/reject.h
@@ -29,7 +29,7 @@
 
 void init_reject(void);
 int check_reject(rb_fde_t *F, struct sockaddr *addr);
-void add_reject(struct Client *, const char *mask1, const char *mask2);
+void add_reject(struct Client *, const char *mask1, const char *mask2, struct ConfItem *aconf, const char *reason);
 int is_reject_ip(struct sockaddr *addr);
 void flush_reject(void);
 int remove_reject_ip(const char *ip);

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -350,6 +350,7 @@ extern void read_conf_files(bool cold);
 extern int attach_conf(struct Client *, struct ConfItem *);
 extern int check_client(struct Client *client_p, struct Client *source_p, const char *);
 
+extern void deref_conf(struct ConfItem *);
 extern int detach_conf(struct Client *);
 
 extern struct ConfItem *find_tkline(const char *, const char *, struct sockaddr *);

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -280,9 +280,8 @@ check_client(struct Client *client_p, struct Client *source_p, const char *usern
 				source_p->name, IsGotId(source_p) ? "" : "~",
 				source_p->username, source_p->sockhost,
 				source_p->localClient->listener->name, port);
-			add_reject(client_p, NULL, NULL);
-			exit_client(client_p, source_p, &me,
-				    "You are not authorised to use this server");
+			add_reject(client_p, NULL, NULL, NULL, "You are not authorised to use this server.");
+			exit_client(client_p, source_p, &me, "You are not authorised to use this server.");
 			break;
 		}
 	case BANNED_CLIENT:
@@ -364,7 +363,7 @@ verify_access(struct Client *client_p, const char *username)
 					form_str(ERR_YOUREBANNEDCREEP),
 					me.name, client_p->name,
 					get_user_ban_reason(aconf));
-		add_reject(client_p, aconf->user, aconf->host);
+		add_reject(client_p, aconf->user, aconf->host, aconf, NULL);
 		return (BANNED_CLIENT);
 	}
 
@@ -529,6 +528,20 @@ attach_iline(struct Client *client_p, struct ConfItem *aconf)
 
 
 	return (attach_conf(client_p, aconf));
+}
+
+/*
+ * deref_conf
+ *
+ * inputs	- ConfItem that is referenced by something other than a client
+ * side effects	- Decrement and free ConfItem if appropriate
+ */
+void
+deref_conf(struct ConfItem *aconf)
+{
+	aconf->clients--;
+	if(!aconf->clients && IsIllegal(aconf))
+		free_conf(aconf);
 }
 
 /*

--- a/ircd/s_user.c
+++ b/ircd/s_user.c
@@ -240,7 +240,7 @@ authd_check(struct Client *client_p, struct Client *source_p)
 
 			sendto_one_notice(source_p, ":*** Your IP address %s is listed in %s",
 				source_p->sockhost, blacklist);
-			add_reject(source_p, NULL, NULL);
+			add_reject(source_p, NULL, NULL, NULL, "Banned (DNS blacklist)");
 			exit_client(client_p, source_p, &me, "Banned (DNS blacklist)");
 			reject = true;
 		}
@@ -283,7 +283,7 @@ authd_check(struct Client *client_p, struct Client *source_p)
 			sendto_one_notice(source_p,
 				":*** Your IP address %s has been detected as an open proxy (type %s, port %s)",
 				source_p->sockhost, proxy, port);
-			add_reject(source_p, NULL, NULL);
+			add_reject(source_p, NULL, NULL, NULL, "Banned (Open proxy)");
 			exit_client(client_p, source_p, &me, "Banned (Open proxy)");
 			reject = true;
 		}
@@ -307,7 +307,7 @@ authd_check(struct Client *client_p, struct Client *source_p)
 
 		sendto_one_notice(source_p, ":*** Rejected by authentication system: %s",
 			reason);
-		add_reject(source_p, NULL, NULL);
+		add_reject(source_p, NULL, NULL, NULL, "Banned (authentication system)");
 		exit_client(client_p, source_p, &me, "Banned (authentication system)");
 		reject = true;
 		break;
@@ -553,7 +553,7 @@ register_local_user(struct Client *client_p, struct Client *source_p)
 	   (xconf = find_xline(source_p->info, 1)) != NULL)
 	{
 		ServerStats.is_ref++;
-		add_reject(source_p, xconf->host, NULL);
+		add_reject(source_p, xconf->host, NULL, NULL, NULL);
 		exit_client(client_p, source_p, &me, "Bad user info");
 		return CLIENT_EXITED;
 	}


### PR DESCRIPTION
rejectcache entries can now use either a K-line aconf or a static string as a reason. This will be sent in a 465 numeric before the usual ERROR. In the case of K-lines, it resembles the 465 you would have been sent without being rejected:

```
; nc -s 127.6.6.6 127.0.0.1 5000
:staberinde.local 465 * :You are banned from this server- Temporary K-line 4320 min. - abc123 (2019/12/31 01.07)
ERROR :Closing Link: (*** Banned (cache))
; nc -s 127.128.0.0 127.0.0.1 5000
:staberinde.local 465 * :You are not authorised to use this server.
ERROR :Closing Link: (*** Banned (cache))
```