### PR TITLE
Add config option to hide durations of temporary K/D-lines

### DIFF
--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -580,6 +580,7 @@ general {
 	global_snotices = yes;
 	dline_with_reason = yes;
 	kline_with_reason = yes;
+	hide_tkdline_duration = no;
 	kline_reason = "K-Lined";
 	identify_service = "NickServ@services.int";
 	identify_command = "IDENTIFY";

--- a/doc/reference.conf
+++ b/doc/reference.conf
@@ -1178,6 +1178,11 @@ general {
 	 */
 	kline_with_reason = yes;
 
+	/* tkline duration: when showing users their k/dline reason (see
+	 * kline_with_reason), don't add "Temporary K-line 123 min."
+	 */
+	hide_tkdline_duration = no;
+
 	/* kline reason: make the users quit message on channels this
 	 * reason instead of the oper's reason.
 	 */

--- a/include/s_conf.h
+++ b/include/s_conf.h
@@ -178,6 +178,7 @@ struct config_file_entry
 	int ts_warn_delta;
 	int dline_with_reason;
 	int kline_with_reason;
+	int hide_tkdline_duration;
 	int warn_no_nline;
 	int nick_delay;
 	int non_redundant_klines;

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -2757,6 +2757,7 @@ static struct ConfEntry conf_general_table[] =
 	{ "hide_spoof_ips",	CF_YESNO, NULL, 0, &ConfigFileEntry.hide_spoof_ips	},
 	{ "dline_with_reason",	CF_YESNO, NULL, 0, &ConfigFileEntry.dline_with_reason	},
 	{ "kline_with_reason",	CF_YESNO, NULL, 0, &ConfigFileEntry.kline_with_reason	},
+	{ "hide_tkdline_duration",	CF_YESNO, NULL, 0, &ConfigFileEntry.hide_tkdline_duration	},
 	{ "map_oper_only",	CF_YESNO, NULL, 0, &ConfigFileEntry.map_oper_only	},
 	{ "max_accept",		CF_INT,   NULL, 0, &ConfigFileEntry.max_accept		},
 	{ "max_monitor",	CF_INT,   NULL, 0, &ConfigFileEntry.max_monitor		},

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1326,7 +1326,8 @@ get_user_ban_reason(struct ConfItem *aconf)
 {
 	static char reasonbuf[BUFSIZE];
 
-	if (aconf->flags & CONF_FLAGS_TEMPORARY &&
+	if (!ConfigFileEntry.hide_tkdline_duration &&
+			aconf->flags & CONF_FLAGS_TEMPORARY &&
 			(aconf->status == CONF_KILL || aconf->status == CONF_DLINE))
 		snprintf(reasonbuf, sizeof reasonbuf,
 				"Temporary %c-line %d min. - ",


### PR DESCRIPTION
When, with the server configured to show K-line reasons, a user matches a temporary K-line, they get a message like:

    :staberinde.local 465 a :You are banned from this server- Temporary K-line 4320 min. - abc123 (2019/12/31 01.45)

which might be helpful in some cases, but is not necessarily information operators would want to reveal. It might also be misleading in cases where the K-line is subject to change or likely to be renewed, as is the case for DNSBL bans, for example.

With this option enabled, the message becomes:

    :staberinde.local 465 a :You are banned from this server- abc123 (2019/12/31 01.45)

just like a permanent K-line.

This change also affects D-lines for the same reasons.