### PR TITLE
Remove from the list of propagated bans on expiry

### DIFF
--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1135,7 +1135,7 @@ deactivate_conf(struct ConfItem *aconf, rb_dlink_node *ptr, time_t now)
 			del_from_resv_hash(aconf->host, aconf);
 			break;
 	}
-	if (aconf->clients > 0 || (aconf->lifetime != 0 && now < aconf->lifetime))
+	if (aconf->lifetime != 0 && now < aconf->lifetime)
 	{
 		aconf->status |= CONF_ILLEGAL;
 	}
@@ -1143,7 +1143,10 @@ deactivate_conf(struct ConfItem *aconf, rb_dlink_node *ptr, time_t now)
 	{
 		if (aconf->lifetime != 0)
 			rb_dlinkDestroy(ptr, &prop_bans);
-		free_conf(aconf);
+		if (aconf->clients == 0)
+			free_conf(aconf);
+		else
+			aconf->status |= CONF_ILLEGAL;
 	}
 }
 


### PR DESCRIPTION
Fixes a use-after-free introduced in 548e31d3b, which fixed a related use-after-free introduced in a9536f755.

I wonder how long I can keep this up?