### PR TITLE
Don't match iline-spoofed IPs for channel bans

### DIFF
--- a/extensions/extb_canjoin.c
+++ b/extensions/extb_canjoin.c
@@ -61,7 +61,7 @@ static int eb_canjoin(const char *data, struct Client *client_p,
 		return EXTBAN_INVALID;
 #endif
 	recurse = 1;
-	ret = is_banned(chptr2, client_p, NULL, NULL, NULL, NULL) == CHFL_BAN ? EXTBAN_MATCH : EXTBAN_NOMATCH;
+	ret = is_banned(chptr2, client_p, NULL, NULL, NULL) == CHFL_BAN ? EXTBAN_MATCH : EXTBAN_NOMATCH;
 	recurse = 0;
 	return ret;
 }

--- a/extensions/extb_hostmask.c
+++ b/extensions/extb_hostmask.c
@@ -32,36 +32,5 @@ _moddeinit(void)
 static int
 eb_hostmask(const char *banstr, struct Client *client_p, struct Channel *chptr, long mode_type)
 {
-	char src_host[NAMELEN + USERLEN + HOSTLEN + 6];
-	char src_iphost[NAMELEN + USERLEN + HOSTLEN + 6];
-	char src_althost[NAMELEN + USERLEN + HOSTLEN + 6];
-	char src_ip4host[NAMELEN + USERLEN + HOSTLEN + 6];
-	struct sockaddr_in ip4;
-	char *s = src_host, *s2 = src_iphost, *s3 = NULL, *s4 = NULL;
-
-	sprintf(src_host, "%s!%s@%s", client_p->name, client_p->username, client_p->host);
-	sprintf(src_iphost, "%s!%s@%s", client_p->name, client_p->username, client_p->sockhost);
-
-	/* handle hostmangling if necessary */
-	if (client_p->localClient->mangledhost != NULL)
-	{
-		if (!strcmp(client_p->host, client_p->localClient->mangledhost))
-			sprintf(src_althost, "%s!%s@%s", client_p->name, client_p->username, client_p->orighost);
-		else if (!IsDynSpoof(client_p))
-			sprintf(src_althost, "%s!%s@%s", client_p->name, client_p->username, client_p->localClient->mangledhost);
-
-		s3 = src_althost;
-	}
-
-	/* handle Teredo if necessary */
-	if (GET_SS_FAMILY(&client_p->localClient->ip) == AF_INET6 && rb_ipv4_from_ipv6((const struct sockaddr_in6 *) &client_p->localClient->ip, &ip4))
-	{
-		sprintf(src_ip4host, "%s!%s@", client_p->name, client_p->username);
-		s4 = src_ip4host + strlen(src_ip4host);
-		rb_inet_ntop_sock((struct sockaddr *)&ip4,
-				s4, src_ip4host + sizeof src_ip4host - s4);
-		s4 = src_ip4host;
-	}
-
-	return match(banstr, s) || match(banstr, s2) || (s3 != NULL && match(banstr, s3)) || (s4 != NULL && match(banstr, s4)) ? EXTBAN_MATCH : EXTBAN_NOMATCH;
+	return client_matches_mask(client_p, banstr) ? EXTBAN_MATCH : EXTBAN_NOMATCH;
 }

--- a/include/channel.h
+++ b/include/channel.h
@@ -215,10 +215,12 @@ extern int can_send(struct Channel *chptr, struct Client *who,
 		    struct membership *);
 extern bool flood_attack_channel(int p_or_n, struct Client *source_p,
 				struct Channel *chptr, char *chname);
+struct matchset;
 extern int is_banned(struct Channel *chptr, struct Client *who,
-		    struct membership *msptr, const char *, const char *, const char **);
+                     struct membership *msptr, const struct matchset *ms,
+                     const char **);
 extern int is_quieted(struct Channel *chptr, struct Client *who,
-		     struct membership *msptr, const char *, const char *);
+		     struct membership *msptr, const struct matchset *ms);
 extern int can_join(struct Client *source_p, struct Channel *chptr,
 		    const char *key, const char **forward);
 

--- a/include/match.h
+++ b/include/match.h
@@ -59,6 +59,17 @@ int comp_with_mask_sock(struct sockaddr *addr, struct sockaddr *dest, unsigned i
 extern char *collapse(char *pattern);
 extern char *collapse_esc(char *pattern);
 
+struct matchset {
+	char host[2][NAMELEN + USERLEN + HOSTLEN + 6];
+	char ip[2][NAMELEN + USERLEN + HOSTIPLEN + 6];
+};
+
+struct Client;
+
+void matchset_for_client(struct Client *who, struct matchset *m);
+bool client_matches_mask(struct Client *who, const char *mask);
+bool matches_mask(const struct matchset *m, const char *mask);
+
 /*
  * irccmp - case insensitive comparison of s1 and s2
  */

--- a/ircd/match.c
+++ b/ircd/match.c
@@ -594,7 +594,12 @@ void matchset_for_client(struct Client *who, struct matchset *m)
 	struct sockaddr_in ip4;
 
 	sprintf(m->host[hostn++], "%s!%s@%s", who->name, who->username, who->host);
-	sprintf(m->ip[ipn++], "%s!%s@%s", who->name, who->username, who->sockhost);
+
+	if (!IsIPSpoof(who))
+	{
+		sprintf(m->ip[ipn++], "%s!%s@%s", who->name, who->username, who->sockhost);
+	}
+
 	if (who->localClient->mangledhost != NULL)
 	{
 		/* if host mangling mode enabled, also check their real host */
@@ -609,7 +614,7 @@ void matchset_for_client(struct Client *who, struct matchset *m)
 			sprintf(m->host[hostn++], "%s!%s@%s", who->name, who->username, who->localClient->mangledhost);
 		}
 	}
-	if (GET_SS_FAMILY(&who->localClient->ip) == AF_INET6 &&
+	if (!IsIPSpoof(who) && GET_SS_FAMILY(&who->localClient->ip) == AF_INET6 &&
 			rb_ipv4_from_ipv6((const struct sockaddr_in6 *)&who->localClient->ip, &ip4))
 	{
 		int n = sprintf(m->ip[ipn++], "%s!%s@", who->name, who->username);

--- a/modules/m_knock.c
+++ b/modules/m_knock.c
@@ -130,8 +130,8 @@ m_knock(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source_
 	if(MyClient(source_p))
 	{
 		/* don't allow a knock if the user is banned */
-		if(is_banned(chptr, source_p, NULL, NULL, NULL, NULL) == CHFL_BAN ||
-			is_quieted(chptr, source_p, NULL, NULL, NULL) == CHFL_BAN)
+		if(is_banned(chptr, source_p, NULL, NULL, NULL) == CHFL_BAN ||
+			is_quieted(chptr, source_p, NULL, NULL) == CHFL_BAN)
 		{
 			sendto_one_numeric(source_p, ERR_CANNOTSENDTOCHAN,
 					   form_str(ERR_CANNOTSENDTOCHAN), name);


### PR DESCRIPTION
Doing this made me notice just how wildly inefficient `$m` is. I think extban functions should get a context struct parameter where we can send the strings, instead of generating them from scratch for each invocation, but that'll be another PR.