### PR TITLE
Make K-line checking more consistent

### DIFF
--- a/ircd/client.c
+++ b/ircd/client.c
@@ -605,9 +605,13 @@ check_one_kline(struct ConfItem *kline)
 			if (comp_with_mask_sock((struct sockaddr *)&client_p->localClient->ip,
 					(struct sockaddr *)&sockaddr, bits))
 				matched = 1;
+			break;
 		case HM_HOST:
 			if (match(kline->host, client_p->orighost))
 				matched = 1;
+			if (match(kline->host, client_p->sockhost))
+				matched = 1;
+			break;
 		}
 
 		if (!matched)


### PR DESCRIPTION
Add missing sockhost check in check_one_kline and do the ipv4-in-ipv6 check everywhere we check klines. Also stop comparing ip4s with ip6s and pointlessly parsing the K-line mask for each loop.