### PR TITLE
Fix invite-notify and move it to an extension

### DIFF
--- a/doc/technical/hooks.txt
+++ b/doc/technical/hooks.txt
@@ -114,6 +114,23 @@ The following hooks are called during various events related to clients.
 			  oldsnomask = new snomask field
 
 
+Channel Hooks
+-------------
+
+"can_invite"             - Called before deciding whether to allow the
+                            /invite command
+                            hdata->chptr = channel being invited to
+                            hdata->msptr = membership of inviter
+                            hdata->client = inviter
+                            hdata->target = invite target
+                            hdata->approved = zero to allow
+                            hdata->error = NULL, or error message
+                              if non-null, `approved` is the numeric
+"invite"                 - Called just before effecting an invite on the
+                            target's server
+                            hdata = as above
+
+
 The following are for debugging and take struct hook_io_data for arguments.
 These can be used for a variety of purposes, but are aimed at the developer
 community.

--- a/extensions/Makefile.am
+++ b/extensions/Makefile.am
@@ -35,6 +35,7 @@ extension_LTLIBRARIES =		\
   force_user_invis.la		\
   helpops.la			\
   hurt.la			\
+  invite_notify.la		\
   ip_cloaking.la		\
   ip_cloaking_old.la		\
   ip_cloaking_3.0.la		\

--- a/extensions/invite_notify.c
+++ b/extensions/invite_notify.c
@@ -1,0 +1,74 @@
+#include <stdinc.h>
+#include <modules.h>
+#include <msgbuf.h>
+#include <client.h>
+#include <hash.h>
+#include <send.h>
+#include <s_serv.h>
+
+static const char inv_notify_desc[] = "Notifies channel on /invite and provides the invite-notify client capability";
+
+static void hook_invite(void *);
+static void m_invited(struct MsgBuf *, struct Client *, struct Client *, int, const char **);
+static unsigned int CAP_INVITE_NOTIFY;
+
+mapi_hfn_list_av1 inv_notify_hfnlist[] = {
+	{ "invite", hook_invite },
+	{ NULL, NULL }
+};
+
+struct Message invited_msgtab = {
+	"INVITED", 0, 0, 0, 0,
+	{mg_ignore, mg_ignore, mg_ignore, mg_ignore, {m_invited, 4}, mg_ignore}
+};
+
+mapi_cap_list_av2 inv_notify_caplist[] = {
+	{ MAPI_CAP_CLIENT, "invite-notify", NULL, &CAP_INVITE_NOTIFY },
+	{ 0, NULL, NULL, NULL }
+};
+
+mapi_clist_av1 inv_notify_clist[] = { &invited_msgtab, NULL };
+
+static void
+invite_notify(struct Client *source, struct Client *target, struct Channel *channel)
+{
+	sendto_channel_local_with_capability(source, CHFL_CHANOP, 0, CAP_INVITE_NOTIFY, channel,
+		":%s NOTICE %s :%s is inviting %s to %s.",
+		me.name, channel->chname, source->name, target->name, channel->chname);
+	sendto_channel_local_with_capability(source, CHFL_CHANOP, CAP_INVITE_NOTIFY, 0, channel,
+		":%s!%s@%s INVITE %s %s", source->name, source->username,
+		source->host, target->name, channel->chname);
+}
+
+static void
+hook_invite(void *data_)
+{
+	hook_data_channel_approval *data = data_;
+
+	if (data->approved)
+		/* Don't notify if another hook is rejecting the invite.
+		 * This won't work if the other hook is after us... but really, it's
+		 * the thought that counts.
+		 */
+		return;
+
+	sendto_server(NULL, NULL, CAP_TS6 | CAP_ENCAP, 0, "ENCAP * INVITED %s %s %s",
+	              use_id(data->client), use_id(data->target),
+	              data->chptr->chname);
+	invite_notify(data->client, data->target, data->chptr);
+}
+
+static void
+m_invited(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p, int parc, const char **parv)
+{
+	struct Client *inviter = find_person(parv[1]);
+	struct Client *target = find_person(parv[2]);
+	struct Channel *chptr = find_channel(parv[3]);
+
+	if (inviter == NULL || target == NULL || chptr == NULL)
+		return;
+
+	invite_notify(inviter, target, chptr);
+}
+
+DECLARE_MODULE_AV2("invite_notify", NULL, NULL, inv_notify_clist, NULL, inv_notify_hfnlist, inv_notify_caplist, NULL, inv_notify_desc);

--- a/include/hook.h
+++ b/include/hook.h
@@ -95,6 +95,7 @@ typedef struct
 	int approved;
 	int dir;
 	const char *modestr;
+	const char *error;
 } hook_data_channel_approval;
 
 typedef struct

--- a/tests/send1.c
+++ b/tests/send1.c
@@ -49,7 +49,7 @@ int rb_gettimeofday(struct timeval *tv, void *tz)
 
 unsigned int CAP_ACCOUNT_TAG;
 unsigned int CAP_SERVER_TIME;
-unsigned int CAP_INVITE_NOTIFY;
+unsigned int CAP_MULTI_PREFIX;
 
 static struct Client *user;
 static struct Client *server;
@@ -1604,10 +1604,10 @@ static void sendto_channel_local_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1617,7 +1617,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -1637,7 +1637,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_VOICE, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_VOICE, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not +v; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1647,7 +1647,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_VOICE, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_VOICE, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not +v; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "Has +v; " MSG);
@@ -1667,7 +1667,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "Has +o; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1677,7 +1677,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "Has +o; " MSG);
@@ -1697,7 +1697,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "Has +o/+v; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1707,7 +1707,7 @@ static void sendto_channel_local_with_capability1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "Has +o/+v; " MSG);
@@ -1734,8 +1734,8 @@ static void sendto_channel_local_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
 	strcpy(user->user->suser, "test");
 	local_chan_o->localClient->caps |= CAP_ACCOUNT_TAG;
@@ -1743,7 +1743,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
 	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1753,7 +1753,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -1773,7 +1773,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_VOICE, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_VOICE, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not +v; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1783,7 +1783,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_VOICE, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_VOICE, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not +v; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "Has +v; " MSG);
@@ -1803,7 +1803,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "Has +o; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1813,7 +1813,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "Has +o; " MSG);
@@ -1833,7 +1833,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test Hello World!" CRLF, local_chan_o, "Has +o/+v; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1843,7 +1843,7 @@ static void sendto_channel_local_with_capability1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability(user, CHFL_CHANOP | CHFL_VOICE, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "Has +o/+v; " MSG);
@@ -1870,10 +1870,10 @@ static void sendto_channel_local_with_capability_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1883,7 +1883,7 @@ static void sendto_channel_local_with_capability_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -1903,7 +1903,7 @@ static void sendto_channel_local_with_capability_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1913,7 +1913,7 @@ static void sendto_channel_local_with_capability_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -1933,7 +1933,7 @@ static void sendto_channel_local_with_capability_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1943,7 +1943,7 @@ static void sendto_channel_local_with_capability_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -1970,8 +1970,8 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_chan_p->user->suser, "test_p");
@@ -1980,7 +1980,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
 	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -1990,7 +1990,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(NULL, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -2010,7 +2010,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2020,7 +2020,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_o, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -2040,7 +2040,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, CAP_INVITE_NOTIFY, 0, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, CAP_MULTI_PREFIX, 0, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test_p Hello World!" CRLF, local_chan_o, "On channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2050,7 +2050,7 @@ static void sendto_channel_local_with_capability_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, 0, CAP_INVITE_NOTIFY, channel, "Hello %s!", "World");
+	sendto_channel_local_with_capability_butone(local_chan_p, ALL_MEMBERS, 0, CAP_MULTI_PREFIX, channel, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "On channel; " MSG);
@@ -2280,10 +2280,10 @@ static void sendto_common_channels_local1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_common_channels_local(local_chan_o, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "Has cap; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2294,7 +2294,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_chan_o, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_chan_o, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "Doesn't have cap; " MSG);
@@ -2316,7 +2316,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2326,7 +2326,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2346,9 +2346,9 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_common_channels_local(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2358,7 +2358,7 @@ static void sendto_common_channels_local1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2385,8 +2385,8 @@ static void sendto_common_channels_local1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
@@ -2395,7 +2395,7 @@ static void sendto_common_channels_local1__tags(void)
 	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
 	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_common_channels_local(local_chan_o, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME ";account=test_o Hello World!" CRLF, local_chan_o, "Has cap; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2406,7 +2406,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_chan_o, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_chan_o, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Has cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "Doesn't have cap; " MSG);
@@ -2430,7 +2430,7 @@ static void sendto_common_channels_local1__tags(void)
 
 	local_no_chan->localClient->caps |= CAP_SERVER_TIME;
 
-	sendto_common_channels_local(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2440,7 +2440,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2460,10 +2460,10 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
 	local_no_chan->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_common_channels_local(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2473,7 +2473,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2495,7 +2495,7 @@ static void sendto_common_channels_local1__tags(void)
 
 	local_no_chan->localClient->caps &= ~CAP_SERVER_TIME;
 
-	sendto_common_channels_local(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2505,7 +2505,7 @@ static void sendto_common_channels_local1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2532,10 +2532,10 @@ static void sendto_common_channels_local_butone1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_common_channels_local_butone(local_chan_o, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2546,7 +2546,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_chan_o, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_chan_o, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_ov, "Doesn't have cap; " MSG);
@@ -2568,7 +2568,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2578,7 +2578,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2598,9 +2598,9 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_common_channels_local_butone(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2610,7 +2610,7 @@ static void sendto_common_channels_local_butone1(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2637,8 +2637,8 @@ static void sendto_common_channels_local_butone1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
 	strcpy(local_chan_o->user->suser, "test_o");
 	strcpy(local_no_chan->user->suser, "test_n");
@@ -2647,7 +2647,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
 	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_common_channels_local_butone(local_chan_o, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_chan_o, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -2658,7 +2658,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_chan_o, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_chan_o, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Is the one (neo); " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_ov, "Doesn't have cap; " MSG);
@@ -2682,7 +2682,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 
 	local_no_chan->localClient->caps |= CAP_SERVER_TIME;
 
-	sendto_common_channels_local_butone(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2692,7 +2692,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2712,10 +2712,10 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	local_no_chan->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_no_chan->localClient->caps |= CAP_MULTI_PREFIX;
 	local_no_chan->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_common_channels_local_butone(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2725,7 +2725,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2747,7 +2747,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 
 	local_no_chan->localClient->caps &= ~CAP_SERVER_TIME;
 
-	sendto_common_channels_local_butone(local_no_chan, CAP_INVITE_NOTIFY, 0, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, CAP_MULTI_PREFIX, 0, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -2757,7 +2757,7 @@ static void sendto_common_channels_local_butone1__tags(void)
 	is_client_sendq_empty(server, MSG);
 	is_client_sendq_empty(server2, MSG);
 
-	sendto_common_channels_local_butone(local_no_chan, 0, CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_common_channels_local_butone(local_no_chan, 0, CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_o, "Not on common channel; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Not on common channel; " MSG);
@@ -3198,10 +3198,10 @@ static void sendto_local_clients_with_capability1(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
-	sendto_local_clients_with_capability(CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
 	is_client_sendq("Hello World!" CRLF, local_chan_o, "Has cap; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -3218,8 +3218,8 @@ static void sendto_local_clients_with_capability1__tags(void)
 {
 	standard_init();
 
-	local_chan_o->localClient->caps |= CAP_INVITE_NOTIFY;
-	local_chan_v->localClient->caps |= CAP_INVITE_NOTIFY;
+	local_chan_o->localClient->caps |= CAP_MULTI_PREFIX;
+	local_chan_v->localClient->caps |= CAP_MULTI_PREFIX;
 
 	strcpy(user->user->suser, "test");
 	strcpy(local_chan_o->user->suser, "test_o");
@@ -3232,7 +3232,7 @@ static void sendto_local_clients_with_capability1__tags(void)
 	local_chan_ov->localClient->caps |= CAP_SERVER_TIME;
 	local_chan_v->localClient->caps |= CAP_ACCOUNT_TAG;
 
-	sendto_local_clients_with_capability(CAP_INVITE_NOTIFY, "Hello %s!", "World");
+	sendto_local_clients_with_capability(CAP_MULTI_PREFIX, "Hello %s!", "World");
 	is_client_sendq_empty(user, "Doesn't have cap; " MSG);
 	is_client_sendq("@time=" ADVENTURE_TIME " Hello World!" CRLF, local_chan_o, "Has cap; " MSG);
 	is_client_sendq_empty(local_chan_ov, "Doesn't have cap; " MSG);
@@ -4913,8 +4913,8 @@ int main(int argc, char *argv[])
 	CAP_SERVER_TIME = capability_get(cli_capindex, "server-time", NULL);
 	ok(CAP_SERVER_TIME != 0, "CAP_SERVER_TIME missing; " MSG);
 
-	CAP_INVITE_NOTIFY = capability_get(cli_capindex, "invite-notify", NULL);
-	ok(CAP_INVITE_NOTIFY != 0, "CAP_INVITE_NOTIFY missing; " MSG);
+	CAP_MULTI_PREFIX = capability_get(cli_capindex, "multi-prefix", NULL);
+	ok(CAP_MULTI_PREFIX != 0, "CAP_MULTI_PREFIX missing; " MSG);
 
 	sendto_one1();
 	sendto_one1__tags();


### PR DESCRIPTION
My motivation for moving out invite-notify is primarily that I want the freedom to not load it, which doesn't seem ideal from a maintenance perspective, but I have tried to test it.

The reason for the rather ugly two-stage solution is that invites can be rejected at the target end, and notifying half the network about an invite that doesn't actually happen seems wrong. This approach has the disadvantage that, if the inviter or invitee quits at the wrong moment, the notification can get lost. I think that's less bad.