### PR TITLE
Skip any unhandled DNS record type

### DIFF
--- a/authd/res.c
+++ b/authd/res.c
@@ -702,13 +702,9 @@ static int proc_answer(struct reslist *request, HEADER * header, char *buf, char
 			rb_strlcpy(request->name, hostbuf, IRCD_RES_HOSTLEN + 1);
 
 			return (1);
-		case T_CNAME:
-			/* real answer will follow */
-			current += rd_length;
-			break;
-		default:
-			break;
 		}
+		/* skip any other record type e.g. CNAME, DNAME; real answer should follow */
+		current += rd_length;
 	}
 
 	return (1);


### PR DESCRIPTION
Currently the DNS resolver handles CNAME by skipping that record in the answer and looking for the subsequent A/AAAA/PTR record.  There are other record types which could be handled in the same way, e.g. DNAME, but their presence currently causes the answer parsing to be abandoned.  A better approach would be to skip *any* other record and just use the first A, AAAA or PTR in the answer, regardless of what comes before it.