### PR TITLE
capability: accept new ownerdata for existing caps

### DIFF
--- a/ircd/capability.c
+++ b/ircd/capability.c
@@ -67,6 +67,11 @@ capability_put(struct CapabilityIndex *idx, const char *cap, void *ownerdata)
 	if ((entry = rb_dictionary_retrieve(idx->cap_dict, cap)) != NULL)
 	{
 		entry->flags &= ~CAP_ORPHANED;
+		if (ownerdata != NULL)
+		{
+			s_assert(entry->ownerdata == NULL);
+			entry->ownerdata = ownerdata;
+		}
 		return (1 << entry->value);
 	}
 


### PR DESCRIPTION
Rejecting this meant that ownerdata for orphaned caps was not restored when those caps were un-orphaned, so reloading e.g. m_sasl would irreversibly disable its visibility hook.