### PR TITLE
m_alias: Preserve protocol framing characters

### DIFF
--- a/include/msgbuf.h
+++ b/include/msgbuf.h
@@ -38,6 +38,7 @@ struct MsgBuf {
 	const char *origin;		/* the origin of the message (or NULL) */
 	const char *target;		/* the target of the message (either NULL, or custom defined) */
 	const char *cmd;		/* the cmd/verb of the message (either NULL, or para[0]) */
+	char *endp;			/* one past the end of the original array */
 
 	size_t n_para;			/* the number of parameters (always at least 1 if a full message) */
 	const char *para[MAXPARA];	/* parameters vector (starting with cmd as para[0]) */
@@ -75,6 +76,12 @@ struct MsgBuf_cache {
  * returns 0 on success, 1 on error.
  */
 int msgbuf_parse(struct MsgBuf *msgbuf, char *line);
+
+/*
+ * Unparse the tail of a msgbuf perfectly, preserving framing details
+ * msgbuf->para[n] will reach to the end of the line
+ */
+void msgbuf_reconstruct_tail(struct MsgBuf *msgbuf, size_t n);
 
 /*
  * unparse a pure MsgBuf into a buffer.

--- a/modules/m_alias.c
+++ b/modules/m_alias.c
@@ -114,7 +114,7 @@ m_alias(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 {
 	struct Client *target_p;
 	struct alias_entry *aptr = rb_dictionary_retrieve(alias_dict, msgbuf->cmd);
-	char *p, *str;
+	char *p;
 
 	if(aptr == NULL)
 	{
@@ -151,8 +151,8 @@ m_alias(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 		return;
 	}
 
-	str = reconstruct_parv(parc - 1, &parv[1]);
-	if(EmptyString(str))
+	msgbuf_reconstruct_tail(msgbuf, 1);
+	if(EmptyString(parv[1]))
 	{
 		sendto_one(client_p, form_str(ERR_NOTEXTTOSEND), me.name, target_p->name);
 		return;
@@ -161,5 +161,5 @@ m_alias(struct MsgBuf *msgbuf, struct Client *client_p, struct Client *source_p,
 	sendto_one(target_p, ":%s PRIVMSG %s :%s",
 			get_id(client_p, target_p),
 			p != NULL ? aptr->target : get_id(target_p, target_p),
-			str);
+			parv[1]);
 }


### PR DESCRIPTION
The introduction of msgbufs made aliases change, e.g., `SET PROPERTY foo  :bar` to `SET PROPERTY foo bar`. By storing just one extra piece of information in `struct MsgBuf`, a pointer to the end of the input string, we gain the ability to restore the input exactly, and can pass it to services exactly as we received it.