### PR TITLE
rename blacklist{} to dnsbl{}

### DIFF
--- a/authd/Makefile.am
+++ b/authd/Makefile.am
@@ -12,7 +12,7 @@ authd_SOURCES =	\
 	res.c \
 	reslib.c \
 	reslist.c \
-	providers/blacklist.c \
+	providers/dnsbl.c \
 	providers/ident.c \
 	providers/rdns.c \
 	providers/opm.c

--- a/authd/provider.c
+++ b/authd/provider.c
@@ -19,7 +19,7 @@
  */
 
 /* The basic design here is to have "authentication providers" that do things
- * like query ident and blacklists and even open proxies.
+ * like query ident and DNSBLs and even open proxies.
  *
  * Providers are registered in the auth_providers linked list. It is planned to
  * use a bitmap to store provider ID's later.
@@ -93,10 +93,10 @@ init_providers(void)
 	timeout_ev = rb_event_addish("provider_timeout_event", provider_timeout_event, NULL, 1);
 
 	/* FIXME must be started before rdns/ident to receive completion notification from them */
-	load_provider(&blacklist_provider);
+	load_provider(&dnsbl_provider);
 	load_provider(&opm_provider);
 
-	/* FIXME must be started after blacklist/opm in case of early completion notifications */
+	/* FIXME must be started after dnsbl/opm in case of early completion notifications */
 	load_provider(&rdns_provider);
 	load_provider(&ident_provider);
 }

--- a/authd/provider.h
+++ b/authd/provider.h
@@ -105,7 +105,7 @@ struct auth_provider
 
 extern struct auth_provider rdns_provider;
 extern struct auth_provider ident_provider;
-extern struct auth_provider blacklist_provider;
+extern struct auth_provider dnsbl_provider;
 extern struct auth_provider opm_provider;
 
 extern rb_dlink_list auth_providers;

--- a/authd/providers/dnsbl.c
+++ b/authd/providers/dnsbl.c
@@ -1,6 +1,6 @@
 /*
  * charybdis: A slightly useful ircd.
- * blacklist.c: Manages DNS blacklist entries and lookups
+ * dnsbl.c: Manages DNSBL entries and lookups
  *
  * Copyright (C) 2006-2011 charybdis development team
  *
@@ -44,7 +44,7 @@
 #include "stdinc.h"
 #include "dns.h"
 
-#define SELF_PID (blacklist_provider.id)
+#define SELF_PID (dnsbl_provider.id)
 
 typedef enum filter_t
 {
@@ -52,12 +52,12 @@ typedef enum filter_t
 	FILTER_LAST = 2,
 } filter_t;
 
-/* Blacklist accepted IP types */
+/* dnsbl accepted IP types */
 #define IPTYPE_IPV4	1
 #define IPTYPE_IPV6	2
 
 /* A configured DNSBL */
-struct blacklist
+struct dnsbl
 {
 	char host[IRCD_RES_HOSTLEN + 1];
 	char reason[BUFSIZE];		/* Reason template (ircd fills in the blanks) */
@@ -65,24 +65,24 @@ struct blacklist
 	rb_dlink_list filters;		/* Filters for queries */
 
 	bool delete;			/* If true delete when no clients */
-	int refcount;			/* When 0 and delete is set, remove this blacklist */
+	int refcount;			/* When 0 and delete is set, remove this dnsbl */
 	unsigned int hits;
 
 	time_t lastwarning;		/* Last warning about garbage replies sent */
 };
 
 /* A lookup in progress for a particular DNSBL for a particular client */
-struct blacklist_lookup
+struct dnsbl_lookup
 {
-	struct blacklist *bl;		/* Blacklist we're checking */
+	struct dnsbl *bl;		/* dnsbl we're checking */
 	struct auth_client *auth;	/* Client */
 	struct dns_query *query;	/* DNS query pointer */
 
 	rb_dlink_node node;
 };
 
-/* A blacklist filter */
-struct blacklist_filter
+/* A dnsbl filter */
+struct dnsbl_filter
 {
 	filter_t type;			/* Type of filter */
 	char filter[HOSTIPLEN];		/* The filter itself */
@@ -90,38 +90,38 @@ struct blacklist_filter
 	rb_dlink_node node;
 };
 
-/* Blacklist user data attached to auth_client instance */
-struct blacklist_user
+/* dnsbl user data attached to auth_client instance */
+struct dnsbl_user
 {
 	bool started;
-	rb_dlink_list queries;		/* Blacklist queries in flight */
+	rb_dlink_list queries;		/* dnsbl queries in flight */
 };
 
 /* public interfaces */
-static void blacklists_destroy(void);
+static void dnsbls_destroy(void);
 
-static bool blacklists_start(struct auth_client *);
-static inline void blacklists_generic_cancel(struct auth_client *, const char *);
-static void blacklists_timeout(struct auth_client *);
-static void blacklists_cancel(struct auth_client *);
-static void blacklists_cancel_none(struct auth_client *);
+static bool dnsbls_start(struct auth_client *);
+static inline void dnsbls_generic_cancel(struct auth_client *, const char *);
+static void dnsbls_timeout(struct auth_client *);
+static void dnsbls_cancel(struct auth_client *);
+static void dnsbls_cancel_none(struct auth_client *);
 
 /* private interfaces */
-static void unref_blacklist(struct blacklist *);
-static struct blacklist *new_blacklist(const char *, const char *, uint8_t, rb_dlink_list *);
-static struct blacklist *find_blacklist(const char *);
-static bool blacklist_check_reply(struct blacklist_lookup *, const char *);
-static void blacklist_dns_callback(const char *, bool, query_type, void *);
-static void initiate_blacklist_dnsquery(struct blacklist *, struct auth_client *);
+static void unref_dnsbl(struct dnsbl *);
+static struct dnsbl *new_dnsbl(const char *, const char *, uint8_t, rb_dlink_list *);
+static struct dnsbl *find_dnsbl(const char *);
+static bool dnsbl_check_reply(struct dnsbl_lookup *, const char *);
+static void dnsbl_dns_callback(const char *, bool, query_type, void *);
+static void initiate_dnsbl_dnsquery(struct dnsbl *, struct auth_client *);
 
 /* Variables */
-static rb_dlink_list blacklist_list = { NULL, NULL, 0 };
-static int blacklist_timeout = BLACKLIST_TIMEOUT_DEFAULT;
+static rb_dlink_list dnsbl_list = { NULL, NULL, 0 };
+static int dnsbl_timeout = DNSBL_TIMEOUT_DEFAULT;
 
 /* private interfaces */
 
 static void
-unref_blacklist(struct blacklist *bl)
+unref_dnsbl(struct dnsbl *bl)
 {
 	rb_dlink_node *ptr, *nptr;
 
@@ -134,23 +134,23 @@ unref_blacklist(struct blacklist *bl)
 			rb_free(ptr);
 		}
 
-		rb_dlinkFindDestroy(bl, &blacklist_list);
+		rb_dlinkFindDestroy(bl, &dnsbl_list);
 		rb_free(bl);
 	}
 }
 
-static struct blacklist *
-new_blacklist(const char *name, const char *reason, uint8_t iptype, rb_dlink_list *filters)
+static struct dnsbl *
+new_dnsbl(const char *name, const char *reason, uint8_t iptype, rb_dlink_list *filters)
 {
-	struct blacklist *bl;
+	struct dnsbl *bl;
 
 	if (name == NULL || reason == NULL || iptype == 0)
 		return NULL;
 
-	if((bl = find_blacklist(name)) == NULL)
+	if((bl = find_dnsbl(name)) == NULL)
 	{
-		bl = rb_malloc(sizeof(struct blacklist));
-		rb_dlinkAddAlloc(bl, &blacklist_list);
+		bl = rb_malloc(sizeof(struct dnsbl));
+		rb_dlinkAddAlloc(bl, &dnsbl_list);
 	}
 	else
 		bl->delete = false;
@@ -166,14 +166,14 @@ new_blacklist(const char *name, const char *reason, uint8_t iptype, rb_dlink_lis
 	return bl;
 }
 
-static struct blacklist *
-find_blacklist(const char *name)
+static struct dnsbl *
+find_dnsbl(const char *name)
 {
 	rb_dlink_node *ptr;
 
-	RB_DLINK_FOREACH(ptr, blacklist_list.head)
+	RB_DLINK_FOREACH(ptr, dnsbl_list.head)
 	{
-		struct blacklist *bl = (struct blacklist *)ptr->data;
+		struct dnsbl *bl = (struct dnsbl *)ptr->data;
 
 		if (!strcasecmp(bl->host, name))
 			return bl;
@@ -183,9 +183,9 @@ find_blacklist(const char *name)
 }
 
 static inline bool
-blacklist_check_reply(struct blacklist_lookup *bllookup, const char *ipaddr)
+dnsbl_check_reply(struct dnsbl_lookup *bllookup, const char *ipaddr)
 {
-	struct blacklist *bl = bllookup->bl;
+	struct dnsbl *bl = bllookup->bl;
 	const char *lastoctet;
 	rb_dlink_node *ptr;
 
@@ -199,7 +199,7 @@ blacklist_check_reply(struct blacklist_lookup *bllookup, const char *ipaddr)
 
 	RB_DLINK_FOREACH(ptr, bl->filters.head)
 	{
-		struct blacklist_filter *filter = ptr->data;
+		struct dnsbl_filter *filter = ptr->data;
 		const char *cmpstr;
 
 		if (filter->type == FILTER_ALL)
@@ -208,7 +208,7 @@ blacklist_check_reply(struct blacklist_lookup *bllookup, const char *ipaddr)
 			cmpstr = lastoctet;
 		else
 		{
-			warn_opers(L_CRIT, "Blacklist: Unknown blacklist filter type (host %s): %d",
+			warn_opers(L_CRIT, "dnsbl: Unknown dnsbl filter type (host %s): %d",
 					bl->host, filter->type);
 			exit(EX_PROVIDER_ERROR);
 		}
@@ -222,7 +222,7 @@ blacklist_check_reply(struct blacklist_lookup *bllookup, const char *ipaddr)
 blwarn:
 	if (bl->lastwarning + 3600 < rb_current_time())
 	{
-		warn_opers(L_WARN, "Garbage/undecipherable reply received from blacklist %s (reply %s)",
+		warn_opers(L_WARN, "Garbage/undecipherable reply received from dnsbl %s (reply %s)",
 				bl->host, ipaddr);
 		bl->lastwarning = rb_current_time();
 	}
@@ -231,11 +231,11 @@ blwarn:
 }
 
 static void
-blacklist_dns_callback(const char *result, bool status, query_type type, void *data)
+dnsbl_dns_callback(const char *result, bool status, query_type type, void *data)
 {
-	struct blacklist_lookup *bllookup = (struct blacklist_lookup *)data;
-	struct blacklist_user *bluser;
-	struct blacklist *bl;
+	struct dnsbl_lookup *bllookup = (struct dnsbl_lookup *)data;
+	struct dnsbl_user *bluser;
+	struct dnsbl *bl;
 	struct auth_client *auth;
 
 	lrb_assert(bllookup != NULL);
@@ -247,16 +247,16 @@ blacklist_dns_callback(const char *result, bool status, query_type type, void *d
 	if((bluser = get_provider_data(auth, SELF_PID)) == NULL)
 		return;
 
-	if (result != NULL && status && blacklist_check_reply(bllookup, result))
+	if (result != NULL && status && dnsbl_check_reply(bllookup, result))
 	{
 		/* Match found, so proceed no further */
 		bl->hits++;
 		reject_client(auth, SELF_PID, bl->host, bl->reason);
-		blacklists_cancel(auth);
+		dnsbls_cancel(auth);
 		return;
 	}
 
-	unref_blacklist(bl);
+	unref_dnsbl(bl);
 	cancel_query(bllookup->query);	/* Ignore future responses */
 	rb_dlinkDelete(&bllookup->node, &bluser->queries);
 	rb_free(bllookup);
@@ -264,8 +264,8 @@ blacklist_dns_callback(const char *result, bool status, query_type type, void *d
 	if(!rb_dlink_list_length(&bluser->queries))
 	{
 		/* Done here */
-		notice_client(auth->cid, "*** IP not found in DNS blacklist%s",
-				rb_dlink_list_length(&blacklist_list) > 1 ? "s" : "");
+		notice_client(auth->cid, "*** No DNSBL entr%s found for this IP",
+				rb_dlink_list_length(&dnsbl_list) > 1 ? "ies" : "y");
 		rb_free(bluser);
 		set_provider_data(auth, SELF_PID, NULL);
 		set_provider_timeout_absolute(auth, SELF_PID, 0);
@@ -276,10 +276,10 @@ blacklist_dns_callback(const char *result, bool status, query_type type, void *d
 }
 
 static void
-initiate_blacklist_dnsquery(struct blacklist *bl, struct auth_client *auth)
+initiate_dnsbl_dnsquery(struct dnsbl *bl, struct auth_client *auth)
 {
-	struct blacklist_lookup *bllookup = rb_malloc(sizeof(struct blacklist_lookup));
-	struct blacklist_user *bluser = get_provider_data(auth, SELF_PID);
+	struct dnsbl_lookup *bllookup = rb_malloc(sizeof(struct dnsbl_lookup));
+	struct dnsbl_user *bluser = get_provider_data(auth, SELF_PID);
 	char buf[IRCD_RES_HOSTLEN + 1];
 	int aftype;
 
@@ -289,23 +289,23 @@ initiate_blacklist_dnsquery(struct blacklist *bl, struct auth_client *auth)
 	aftype = GET_SS_FAMILY(&auth->c_addr);
 	if((aftype == AF_INET && (bl->iptype & IPTYPE_IPV4) == 0) ||
 		(aftype == AF_INET6 && (bl->iptype & IPTYPE_IPV6) == 0))
-		/* Incorrect blacklist type for this IP... */
+		/* Incorrect dnsbl type for this IP... */
 	{
 		rb_free(bllookup);
 		return;
 	}
 
 	build_rdns(buf, sizeof(buf), &auth->c_addr, bl->host);
-	bllookup->query = lookup_ip(buf, AF_INET, blacklist_dns_callback, bllookup);
+	bllookup->query = lookup_ip(buf, AF_INET, dnsbl_dns_callback, bllookup);
 
 	rb_dlinkAdd(bllookup, &bllookup->node, &bluser->queries);
 	bl->refcount++;
 }
 
 static inline bool
-lookup_all_blacklists(struct auth_client *auth)
+lookup_all_dnsbls(struct auth_client *auth)
 {
-	struct blacklist_user *bluser = get_provider_data(auth, SELF_PID);
+	struct dnsbl_user *bluser = get_provider_data(auth, SELF_PID);
 	rb_dlink_node *ptr;
 	int iptype;
 
@@ -317,56 +317,56 @@ lookup_all_blacklists(struct auth_client *auth)
 		return false;
 
 	bluser->started = true;
-	notice_client(auth->cid, "*** Checking your IP against DNS blacklist%s",
-			rb_dlink_list_length(&blacklist_list) > 1 ? "s" : "");
+	notice_client(auth->cid, "*** Checking your IP against DNSBL%s",
+			rb_dlink_list_length(&dnsbl_list) > 1 ? "s" : "");
 
-	RB_DLINK_FOREACH(ptr, blacklist_list.head)
+	RB_DLINK_FOREACH(ptr, dnsbl_list.head)
 	{
-		struct blacklist *bl = (struct blacklist *)ptr->data;
+		struct dnsbl *bl = (struct dnsbl *)ptr->data;
 
 		if (!bl->delete && (bl->iptype & iptype))
-			initiate_blacklist_dnsquery(bl, auth);
+			initiate_dnsbl_dnsquery(bl, auth);
 	}
 
 	if(!rb_dlink_list_length(&bluser->queries))
 		/* None checked. */
 		return false;
 
-	set_provider_timeout_relative(auth, SELF_PID, blacklist_timeout);
+	set_provider_timeout_relative(auth, SELF_PID, dnsbl_timeout);
 
 	return true;
 }
 
 static inline void
-delete_blacklist(struct blacklist *bl)
+delete_dnsbl(struct dnsbl *bl)
 {
 	if (bl->refcount > 0)
 		bl->delete = true;
 	else
 	{
-		rb_dlinkFindDestroy(bl, &blacklist_list);
+		rb_dlinkFindDestroy(bl, &dnsbl_list);
 		rb_free(bl);
 	}
 }
 
 static void
-delete_all_blacklists(void)
+delete_all_dnsbls(void)
 {
 	rb_dlink_node *ptr, *nptr;
 
-	RB_DLINK_FOREACH_SAFE(ptr, nptr, blacklist_list.head)
+	RB_DLINK_FOREACH_SAFE(ptr, nptr, dnsbl_list.head)
 	{
-		delete_blacklist(ptr->data);
+		delete_dnsbl(ptr->data);
 	}
 }
 
 /* public interfaces */
 static bool
-blacklists_start(struct auth_client *auth)
+dnsbls_start(struct auth_client *auth)
 {
 	lrb_assert(get_provider_data(auth, SELF_PID) == NULL);
 
-	if (!rb_dlink_list_length(&blacklist_list)) {
+	if (!rb_dlink_list_length(&dnsbl_list)) {
 		/* Nothing to do... */
 		provider_done(auth, SELF_PID);
 		return true;
@@ -374,12 +374,12 @@ blacklists_start(struct auth_client *auth)
 
 	auth_client_ref(auth);
 
-	set_provider_data(auth, SELF_PID, rb_malloc(sizeof(struct blacklist_user)));
+	set_provider_data(auth, SELF_PID, rb_malloc(sizeof(struct dnsbl_user)));
 
 	if (run_after_provider(auth, "rdns") && run_after_provider(auth, "ident")) {
 		/* Start the lookup if ident and rdns are finished, or not loaded. */
-		if (!lookup_all_blacklists(auth)) {
-			blacklists_cancel_none(auth);
+		if (!lookup_all_dnsbls(auth)) {
+			dnsbls_cancel_none(auth);
 			return true;
 		}
 	}
@@ -389,30 +389,30 @@ blacklists_start(struct auth_client *auth)
 
 /* This is called every time a provider is completed as long as we are marked not done */
 static void
-blacklists_initiate(struct auth_client *auth, uint32_t provider)
+dnsbls_initiate(struct auth_client *auth, uint32_t provider)
 {
-	struct blacklist_user *bluser = get_provider_data(auth, SELF_PID);
+	struct dnsbl_user *bluser = get_provider_data(auth, SELF_PID);
 
 	lrb_assert(provider != SELF_PID);
 	lrb_assert(!is_provider_done(auth, SELF_PID));
-	lrb_assert(rb_dlink_list_length(&blacklist_list) > 0);
+	lrb_assert(rb_dlink_list_length(&dnsbl_list) > 0);
 
 	if (bluser == NULL || bluser->started) {
 		/* Nothing to do */
 		return;
 	} else if (run_after_provider(auth, "rdns") && run_after_provider(auth, "ident")) {
 		/* Start the lookup if ident and rdns are finished, or not loaded. */
-		if (!lookup_all_blacklists(auth)) {
-			blacklists_cancel_none(auth);
+		if (!lookup_all_dnsbls(auth)) {
+			dnsbls_cancel_none(auth);
 		}
 	}
 }
 
 static inline void
-blacklists_generic_cancel(struct auth_client *auth, const char *message)
+dnsbls_generic_cancel(struct auth_client *auth, const char *message)
 {
 	rb_dlink_node *ptr, *nptr;
-	struct blacklist_user *bluser = get_provider_data(auth, SELF_PID);
+	struct dnsbl_user *bluser = get_provider_data(auth, SELF_PID);
 
 	if(bluser == NULL)
 		return;
@@ -423,10 +423,10 @@ blacklists_generic_cancel(struct auth_client *auth, const char *message)
 
 		RB_DLINK_FOREACH_SAFE(ptr, nptr, bluser->queries.head)
 		{
-			struct blacklist_lookup *bllookup = ptr->data;
+			struct dnsbl_lookup *bllookup = ptr->data;
 
 			cancel_query(bllookup->query);
-			unref_blacklist(bllookup->bl);
+			unref_dnsbl(bllookup->bl);
 
 			rb_dlinkDelete(&bllookup->node, &bluser->queries);
 			rb_free(bllookup);
@@ -442,40 +442,40 @@ blacklists_generic_cancel(struct auth_client *auth, const char *message)
 }
 
 static void
-blacklists_timeout(struct auth_client *auth)
+dnsbls_timeout(struct auth_client *auth)
 {
-	blacklists_generic_cancel(auth, "*** No response from DNS blacklists");
+	dnsbls_generic_cancel(auth, "*** No response from DNS dnsbls");
 }
 
 static void
-blacklists_cancel(struct auth_client *auth)
+dnsbls_cancel(struct auth_client *auth)
 {
-	blacklists_generic_cancel(auth, "*** Aborting DNS blacklist checks");
+	dnsbls_generic_cancel(auth, "*** Aborting DNS dnsbl checks");
 }
 
 static void
-blacklists_cancel_none(struct auth_client *auth)
+dnsbls_cancel_none(struct auth_client *auth)
 {
-	blacklists_generic_cancel(auth, "*** Could not check DNS blacklists");
+	dnsbls_generic_cancel(auth, "*** Could not check DNS dnsbls");
 }
 
 static void
-blacklists_destroy(void)
+dnsbls_destroy(void)
 {
 	rb_dictionary_iter iter;
 	struct auth_client *auth;
 
 	RB_DICTIONARY_FOREACH(auth, &iter, auth_clients)
 	{
-		blacklists_cancel(auth);
+		dnsbls_cancel(auth);
 		/* auth is now invalid as we have no reference */
 	}
 
-	delete_all_blacklists();
+	delete_all_dnsbls();
 }
 
 static void
-add_conf_blacklist(const char *key, int parc, const char **parv)
+add_conf_dnsbl(const char *key, int parc, const char **parv)
 {
 	rb_dlink_list filters = { NULL, NULL, 0 };
 	char *tmp, *elemlist = rb_strdup(parv[2]);
@@ -486,18 +486,18 @@ add_conf_blacklist(const char *key, int parc, const char **parv)
 
 	for(char *elem = rb_strtok_r(elemlist, ",", &tmp); elem; elem = rb_strtok_r(NULL, ",", &tmp))
 	{
-		struct blacklist_filter *filter = rb_malloc(sizeof(struct blacklist_filter));
+		struct dnsbl_filter *filter = rb_malloc(sizeof(struct dnsbl_filter));
 		int dot_c = 0;
 		filter_t type = FILTER_LAST;
 
-		/* Check blacklist filter type and for validity */
+		/* Check dnsbl filter type and for validity */
 		for(char *c = elem; *c != '\0'; c++)
 		{
 			if(*c == '.')
 			{
 				if(++dot_c > 3)
 				{
-					warn_opers(L_CRIT, "Blacklist: addr_conf_blacklist got a bad filter (too many octets)");
+					warn_opers(L_CRIT, "dnsbl: addr_conf_dnsbl got a bad filter (too many octets)");
 					exit(EX_PROVIDER_ERROR);
 				}
 
@@ -505,7 +505,7 @@ add_conf_blacklist(const char *key, int parc, const char **parv)
 			}
 			else if(!isdigit(*c))
 			{
-				warn_opers(L_CRIT, "Blacklist: addr_conf_blacklist got a bad filter (invalid character in blacklist filter: %c)",
+				warn_opers(L_CRIT, "dnsbl: addr_conf_dnsbl got a bad filter (invalid character in dnsbl filter: %c)",
 						*c);
 				exit(EX_PROVIDER_ERROR);
 			}
@@ -513,7 +513,7 @@ add_conf_blacklist(const char *key, int parc, const char **parv)
 
 		if(dot_c > 0 && dot_c < 3)
 		{
-			warn_opers(L_CRIT, "Blacklist: addr_conf_blacklist got a bad filter (insufficient octets)");
+			warn_opers(L_CRIT, "dnsbl: addr_conf_dnsbl got a bad filter (insufficient octets)");
 			exit(EX_PROVIDER_ERROR);
 		}
 
@@ -526,56 +526,56 @@ end:
 	rb_free(elemlist);
 
 	iptype = atoi(parv[1]) & 0x3;
-	if(new_blacklist(parv[0], parv[3], iptype, &filters) == NULL)
+	if(new_dnsbl(parv[0], parv[3], iptype, &filters) == NULL)
 	{
-		warn_opers(L_CRIT, "Blacklist: addr_conf_blacklist got a malformed blacklist");
+		warn_opers(L_CRIT, "dnsbl: addr_conf_dnsbl got a malformed dnsbl");
 		exit(EX_PROVIDER_ERROR);
 	}
 }
 
 static void
-del_conf_blacklist(const char *key, int parc, const char **parv)
+del_conf_dnsbl(const char *key, int parc, const char **parv)
 {
-	struct blacklist *bl = find_blacklist(parv[0]);
+	struct dnsbl *bl = find_dnsbl(parv[0]);
 	if(bl == NULL)
 	{
 		/* Not fatal for now... */
-		warn_opers(L_WARN, "Blacklist: tried to remove nonexistent blacklist %s", parv[0]);
+		warn_opers(L_WARN, "dnsbl: tried to remove nonexistent dnsbl %s", parv[0]);
 		return;
 	}
 
-	delete_blacklist(bl);
+	delete_dnsbl(bl);
 }
 
 static void
-del_conf_blacklist_all(const char *key, int parc, const char **parv)
+del_conf_dnsbl_all(const char *key, int parc, const char **parv)
 {
-	delete_all_blacklists();
+	delete_all_dnsbls();
 }
 
 static void
-add_conf_blacklist_timeout(const char *key, int parc, const char **parv)
+add_conf_dnsbl_timeout(const char *key, int parc, const char **parv)
 {
 	int timeout = atoi(parv[0]);
 
 	if(timeout < 0)
 	{
-		warn_opers(L_CRIT, "Blacklist: blacklist timeout < 0 (value: %d)", timeout);
+		warn_opers(L_CRIT, "dnsbl: dnsbl timeout < 0 (value: %d)", timeout);
 		exit(EX_PROVIDER_ERROR);
 	}
 
-	blacklist_timeout = timeout;
+	dnsbl_timeout = timeout;
 }
 
 #if 0
 static void
-blacklist_stats(uint32_t rid, char letter)
+dnsbl_stats(uint32_t rid, char letter)
 {
 	rb_dlink_node *ptr;
 
-	RB_DLINK_FOREACH(ptr, blacklist_list.head)
+	RB_DLINK_FOREACH(ptr, dnsbl_list.head)
 	{
-		struct blacklist *bl = ptr->data;
+		struct dnsbl *bl = ptr->data;
 
 		if(bl->delete)
 			continue;
@@ -587,24 +587,24 @@ blacklist_stats(uint32_t rid, char letter)
 }
 #endif
 
-struct auth_opts_handler blacklist_options[] =
+struct auth_opts_handler dnsbl_options[] =
 {
-	{ "rbl", 4, add_conf_blacklist },
-	{ "rbl_del", 1, del_conf_blacklist },
-	{ "rbl_del_all", 0, del_conf_blacklist_all },
-	{ "rbl_timeout", 1, add_conf_blacklist_timeout },
+	{ "rbl", 4, add_conf_dnsbl },
+	{ "rbl_del", 1, del_conf_dnsbl },
+	{ "rbl_del_all", 0, del_conf_dnsbl_all },
+	{ "rbl_timeout", 1, add_conf_dnsbl_timeout },
 	{ NULL, 0, NULL },
 };
 
-struct auth_provider blacklist_provider =
+struct auth_provider dnsbl_provider =
 {
-	.name = "blacklist",
+	.name = "dnsbl",
 	.letter = 'B',
-	.destroy = blacklists_destroy,
-	.start = blacklists_start,
-	.cancel = blacklists_cancel,
-	.timeout = blacklists_timeout,
-	.completed = blacklists_initiate,
-	.opt_handlers = blacklist_options,
-	/* .stats_handler = { 'B', blacklist_stats }, */
+	.destroy = dnsbls_destroy,
+	.start = dnsbls_start,
+	.cancel = dnsbls_cancel,
+	.timeout = dnsbls_timeout,
+	.completed = dnsbls_initiate,
+	.opt_handlers = dnsbl_options,
+	/* .stats_handler = { 'B', dnsbl_stats }, */
 };

--- a/doc/ircd.conf.example
+++ b/doc/ircd.conf.example
@@ -383,14 +383,14 @@ serverhide {
 	disable_hidden = no;
 };
 
-/* These are the blacklist settings.
+/* These are the DNSBL settings.
  * You can have multiple combinations of host and rejection reasons.
  * They are used in pairs of one host/rejection reason.
  *
- * These settings should be adequate for most networks.
+ * The default settings should be adequate for most networks.
  *
- * Word to the wise: Do not use blacklists like SPEWS for blocking IRC
- * connections.
+ * It is not recommended to use DNSBL services designed for e-mail spam
+ * prevention, such as SPEWS for blocking IRC connections.
  *
  * As of charybdis 2.2, you can do some keyword substitution on the rejection
  * reason. The available keyword substitutions are:
@@ -410,13 +410,13 @@ serverhide {
  * is considered a match. If included, a comma-separated list of *quoted*
  * strings is allowed to match queries. They may be of the format "0" to "255"
  * to match the final octet (e.g. 127.0.0.1) or "127.x.y.z" to explicitly match
- * an A record. The blacklist is only applied if it matches anything in the
+ * an A record. The DNSBL match is only applied if it matches anything in the
  * list. You may freely mix full IP's and final octets.
  *
- * Consult your blacklist provider for the meaning of these parameters; they
- * are usually used to denote different ban types.
+ * Consult your DNSBL provider for the meaning of these parameters; they
+ * are usually used to denote different block reasons.
  */
-blacklist {
+dnsbl {
 	host = "rbl.efnetrbl.org";
 	type = ipv4;
 	reject_reason = "${nick}, your IP (${ip}) is listed in EFnet's RBL. For assistance, see http://efnetrbl.org/?i=${ip}";

--- a/include/authproc.h
+++ b/include/authproc.h
@@ -30,7 +30,7 @@
 #include "rb_dictionary.h"
 #include "client.h"
 
-struct BlacklistStats
+struct DNSBLEntryStats
 {
 	char *host;
 	uint8_t iptype;
@@ -60,7 +60,7 @@ enum
 
 extern rb_helper *authd_helper;
 
-extern rb_dictionary *bl_stats;
+extern rb_dictionary *dnsbl_stats;
 extern rb_dlink_list opm_list;
 extern struct OPMListener opm_listeners[LISTEN_LAST];
 
@@ -76,9 +76,9 @@ void authd_accept_client(struct Client *client_p, const char *ident, const char 
 void authd_reject_client(struct Client *client_p, const char *ident, const char *host, char cause, const char *data, const char *reason);
 void authd_abort_client(struct Client *);
 
-void add_blacklist(const char *host, const char *reason, uint8_t iptype, rb_dlink_list *filters);
-void del_blacklist(const char *host);
-void del_blacklist_all(void);
+void add_dnsbl_entry(const char *host, const char *reason, uint8_t iptype, rb_dlink_list *filters);
+void del_dnsbl_entry(const char *host);
+void del_dnsbl_entry_all(void);
 
 bool set_authd_timeout(const char *key, int timeout);
 void ident_check_enable(bool enabled);

--- a/include/client.h
+++ b/include/client.h
@@ -36,9 +36,6 @@
 #include "ircd.h"
 #include "privilege.h"
 
-/* other structs */
-struct Blacklist;
-
 /* we store ipv6 ips for remote clients, so this needs to be v6 always */
 #define HOSTIPLEN	53	/* sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255.ipv6") */
 #define PASSWDLEN	128

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -77,7 +77,7 @@ extern const char *ircd_paths[IRCD_PATH_COUNT];
 #define LINKS_DELAY_DEFAULT		300
 #define MAX_TARGETS_DEFAULT		4		/* default for max_targets */
 #define IDENT_TIMEOUT_DEFAULT		5
-#define BLACKLIST_TIMEOUT_DEFAULT	10
+#define DNSBL_TIMEOUT_DEFAULT		10
 #define OPM_TIMEOUT_DEFAULT		10
 #define RDNS_TIMEOUT_DEFAULT		5
 #define MIN_JOIN_LEAVE_TIME		60

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -55,10 +55,10 @@ static struct oper_conf *yy_oper = NULL;
 
 static struct alias_entry *yy_alias = NULL;
 
-static char *yy_blacklist_host = NULL;
-static char *yy_blacklist_reason = NULL;
-static uint8_t yy_blacklist_iptype = 0;
-static rb_dlink_list yy_blacklist_filters = { NULL, NULL, 0 };
+static char *yy_dnsbl_entry_host = NULL;
+static char *yy_dnsbl_entry_reason = NULL;
+static uint8_t yy_dnsbl_entry_iptype = 0;
+static rb_dlink_list yy_dnsbl_entry_filters = { NULL, NULL, 0 };
 
 static char *yy_opm_address_ipv4 = NULL;
 static char *yy_opm_address_ipv6 = NULL;
@@ -1903,57 +1903,64 @@ conf_set_channel_autochanmodes(void *data)
 }
 
 /* XXX for below */
-static void conf_set_blacklist_reason(void *data);
+static void conf_set_dnsbl_entry_reason(void *data);
 
 #define IPTYPE_IPV4 1
 #define IPTYPE_IPV6 2
 
-static void
-conf_set_blacklist_host(void *data)
+static int
+conf_warn_blacklist_deprecation(struct TopConf *tc)
 {
-	if (yy_blacklist_host)
-	{
-		conf_report_error("blacklist::host %s overlaps existing host %s",
-			(char *)data, yy_blacklist_host);
-
-		/* Cleanup */
-		conf_set_blacklist_reason(NULL);
-		return;
-	}
-
-	yy_blacklist_iptype |= IPTYPE_IPV4;
-	yy_blacklist_host = rb_strdup(data);
+	conf_report_error("blacklist{} blocks have been deprecated -- use dnsbl{} blocks instead.");
+	return 0;
 }
 
 static void
-conf_set_blacklist_type(void *data)
+conf_set_dnsbl_entry_host(void *data)
+{
+	if (yy_dnsbl_entry_host)
+	{
+		conf_report_error("dnsbl::host %s overlaps existing host %s",
+			(char *)data, yy_dnsbl_entry_host);
+
+		/* Cleanup */
+		conf_set_dnsbl_entry_reason(NULL);
+		return;
+	}
+
+	yy_dnsbl_entry_iptype |= IPTYPE_IPV4;
+	yy_dnsbl_entry_host = rb_strdup(data);
+}
+
+static void
+conf_set_dnsbl_entry_type(void *data)
 {
 	conf_parm_t *args = data;
 
 	/* Don't assume we have either if we got here */
-	yy_blacklist_iptype = 0;
+	yy_dnsbl_entry_iptype = 0;
 
 	for (; args; args = args->next)
 	{
 		if (!rb_strcasecmp(args->v.string, "ipv4"))
-			yy_blacklist_iptype |= IPTYPE_IPV4;
+			yy_dnsbl_entry_iptype |= IPTYPE_IPV4;
 		else if (!rb_strcasecmp(args->v.string, "ipv6"))
-			yy_blacklist_iptype |= IPTYPE_IPV6;
+			yy_dnsbl_entry_iptype |= IPTYPE_IPV6;
 		else
-			conf_report_error("blacklist::type has unknown address family %s",
+			conf_report_error("dnsbl::type has unknown address family %s",
 					  args->v.string);
 	}
 
 	/* If we have neither, just default to IPv4 */
-	if (!yy_blacklist_iptype)
+	if (!yy_dnsbl_entry_iptype)
 	{
-		conf_report_warning("blacklist::type has neither IPv4 nor IPv6 (defaulting to IPv4)");
-		yy_blacklist_iptype = IPTYPE_IPV4;
+		conf_report_warning("dnsbl::type has neither IPv4 nor IPv6 (defaulting to IPv4)");
+		yy_dnsbl_entry_iptype = IPTYPE_IPV4;
 	}
 }
 
 static void
-conf_set_blacklist_matches(void *data)
+conf_set_dnsbl_entry_matches(void *data)
 {
 	conf_parm_t *args = data;
 	enum filter_t { FILTER_NONE, FILTER_ALL, FILTER_LAST };
@@ -1966,19 +1973,19 @@ conf_set_blacklist_matches(void *data)
 
 		if (CF_TYPE(args->type) != CF_QSTRING)
 		{
-			conf_report_error("blacklist::matches -- must be quoted string");
+			conf_report_error("dnsbl::matches -- must be quoted string");
 			continue;
 		}
 
 		if (str == NULL)
 		{
-			conf_report_error("blacklist::matches -- invalid entry");
+			conf_report_error("dnsbl::matches -- invalid entry");
 			continue;
 		}
 
 		if (strlen(str) > HOSTIPLEN)
 		{
-			conf_report_error("blacklist::matches has an entry too long: %s",
+			conf_report_error("dnsbl::matches has an entry too long: %s",
 					str);
 			continue;
 		}
@@ -1990,7 +1997,7 @@ conf_set_blacklist_matches(void *data)
 				type = FILTER_ALL;
 			else if (!isdigit((unsigned char)*p))
 			{
-				conf_report_error("blacklist::matches has invalid IP match entry %s",
+				conf_report_error("dnsbl::matches has invalid IP match entry %s",
 						str);
 				type = FILTER_NONE;
 				break;
@@ -2003,7 +2010,7 @@ conf_set_blacklist_matches(void *data)
 			struct rb_sockaddr_storage tmp;
 			if (rb_inet_pton(AF_INET, str, &tmp) <= 0)
 			{
-				conf_report_error("blacklist::matches has invalid IP match entry %s",
+				conf_report_error("dnsbl::matches has invalid IP match entry %s",
 						str);
 				continue;
 			}
@@ -2013,7 +2020,7 @@ conf_set_blacklist_matches(void *data)
 			/* Verify it's the correct length */
 			if (strlen(str) > 3)
 			{
-				conf_report_error("blacklist::matches has invalid octet match entry %s",
+				conf_report_error("dnsbl::matches has invalid octet match entry %s",
 						str);
 				continue;
 			}
@@ -2023,61 +2030,61 @@ conf_set_blacklist_matches(void *data)
 			continue; /* Invalid entry */
 		}
 
-		rb_dlinkAddAlloc(rb_strdup(str), &yy_blacklist_filters);
+		rb_dlinkAddAlloc(rb_strdup(str), &yy_dnsbl_entry_filters);
 	}
 }
 
 static void
-conf_set_blacklist_reason(void *data)
+conf_set_dnsbl_entry_reason(void *data)
 {
 	rb_dlink_node *ptr, *nptr;
 
-	if (yy_blacklist_host && data)
+	if (yy_dnsbl_entry_host && data)
 	{
-		yy_blacklist_reason = rb_strdup(data);
-		if (yy_blacklist_iptype & IPTYPE_IPV6)
+		yy_dnsbl_entry_reason = rb_strdup(data);
+		if (yy_dnsbl_entry_iptype & IPTYPE_IPV6)
 		{
 			/* Make sure things fit (magic number 64 = alnum count + dots)
 			 * Example: 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa
 			 */
-			if ((64 + strlen(yy_blacklist_host)) > IRCD_RES_HOSTLEN)
+			if ((64 + strlen(yy_dnsbl_entry_host)) > IRCD_RES_HOSTLEN)
 			{
-				conf_report_error("blacklist::host %s results in IPv6 queries that are too long",
-						  yy_blacklist_host);
+				conf_report_error("dnsbl::host %s results in IPv6 queries that are too long",
+						  yy_dnsbl_entry_host);
 				goto cleanup_bl;
 			}
 		}
 		/* Avoid doing redundant check, IPv6 is bigger than IPv4 --Elizabeth */
-		if ((yy_blacklist_iptype & IPTYPE_IPV4) && !(yy_blacklist_iptype & IPTYPE_IPV6))
+		if ((yy_dnsbl_entry_iptype & IPTYPE_IPV4) && !(yy_dnsbl_entry_iptype & IPTYPE_IPV6))
 		{
 			/* Make sure things fit for worst case (magic number 16 = number of nums + dots)
 			 * Example: 127.127.127.127.in-addr.arpa
 			 */
-			if ((16 + strlen(yy_blacklist_host)) > IRCD_RES_HOSTLEN)
+			if ((16 + strlen(yy_dnsbl_entry_host)) > IRCD_RES_HOSTLEN)
 			{
-				conf_report_error("blacklist::host %s results in IPv4 queries that are too long",
-						  yy_blacklist_host);
+				conf_report_error("dnsbl::host %s results in IPv4 queries that are too long",
+						  yy_dnsbl_entry_host);
 				goto cleanup_bl;
 			}
 		}
 
-		add_dnsbl_entry(yy_blacklist_host, yy_blacklist_reason, yy_blacklist_iptype, &yy_blacklist_filters);
+		add_dnsbl_entry(yy_dnsbl_entry_host, yy_dnsbl_entry_reason, yy_dnsbl_entry_iptype, &yy_dnsbl_entry_filters);
 	}
 
 cleanup_bl:
-	RB_DLINK_FOREACH_SAFE(ptr, nptr, yy_blacklist_filters.head)
+	RB_DLINK_FOREACH_SAFE(ptr, nptr, yy_dnsbl_entry_filters.head)
 	{
 		rb_free(ptr->data);
-		rb_dlinkDestroy(ptr, &yy_blacklist_filters);
+		rb_dlinkDestroy(ptr, &yy_dnsbl_entry_filters);
 	}
 
-	yy_blacklist_filters = (rb_dlink_list){ NULL, NULL, 0 };
+	yy_dnsbl_entry_filters = (rb_dlink_list){ NULL, NULL, 0 };
 
-	rb_free(yy_blacklist_host);
-	rb_free(yy_blacklist_reason);
-	yy_blacklist_host = NULL;
-	yy_blacklist_reason = NULL;
-	yy_blacklist_iptype = 0;
+	rb_free(yy_dnsbl_entry_host);
+	rb_free(yy_dnsbl_entry_reason);
+	yy_dnsbl_entry_host = NULL;
+	yy_dnsbl_entry_reason = NULL;
+	yy_dnsbl_entry_iptype = 0;
 }
 
 
@@ -2893,11 +2900,17 @@ newconf_init()
 	add_conf_item("alias", "name", CF_QSTRING, conf_set_alias_name);
 	add_conf_item("alias", "target", CF_QSTRING, conf_set_alias_target);
 
-	add_top_conf("blacklist", NULL, NULL, NULL);
-	add_conf_item("blacklist", "host", CF_QSTRING, conf_set_blacklist_host);
-	add_conf_item("blacklist", "type", CF_STRING | CF_FLIST, conf_set_blacklist_type);
-	add_conf_item("blacklist", "matches", CF_QSTRING | CF_FLIST, conf_set_blacklist_matches);
-	add_conf_item("blacklist", "reject_reason", CF_QSTRING, conf_set_blacklist_reason);
+	add_top_conf("dnsbl", NULL, NULL, NULL);
+	add_conf_item("dnsbl", "host", CF_QSTRING, conf_set_dnsbl_entry_host);
+	add_conf_item("dnsbl", "type", CF_STRING | CF_FLIST, conf_set_dnsbl_entry_type);
+	add_conf_item("dnsbl", "matches", CF_QSTRING | CF_FLIST, conf_set_dnsbl_entry_matches);
+	add_conf_item("dnsbl", "reject_reason", CF_QSTRING, conf_set_dnsbl_entry_reason);
+
+	add_top_conf("blacklist", conf_warn_blacklist_deprecation, NULL, NULL);
+	add_conf_item("blacklist", "host", CF_QSTRING, conf_set_dnsbl_entry_host);
+	add_conf_item("blacklist", "type", CF_STRING | CF_FLIST, conf_set_dnsbl_entry_type);
+	add_conf_item("blacklist", "matches", CF_QSTRING | CF_FLIST, conf_set_dnsbl_entry_matches);
+	add_conf_item("blacklist", "reject_reason", CF_QSTRING, conf_set_dnsbl_entry_reason);
 
 	add_top_conf("opm", conf_begin_opm, conf_end_opm, NULL);
 	add_conf_item("opm", "timeout", CF_INT, conf_set_opm_timeout);

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -2061,7 +2061,7 @@ conf_set_blacklist_reason(void *data)
 			}
 		}
 
-		add_blacklist(yy_blacklist_host, yy_blacklist_reason, yy_blacklist_iptype, &yy_blacklist_filters);
+		add_dnsbl_entry(yy_blacklist_host, yy_blacklist_reason, yy_blacklist_iptype, &yy_blacklist_filters);
 	}
 
 cleanup_bl:

--- a/ircd/s_conf.c
+++ b/ircd/s_conf.c
@@ -1566,7 +1566,7 @@ clear_out_old_conf(void)
 		alias_dict = NULL;
 	}
 
-	del_blacklist_all();
+	del_dnsbl_entry_all();
 
 	privilegeset_mark_all_illegal();
 

--- a/modules/m_stats.c
+++ b/modules/m_stats.c
@@ -756,12 +756,12 @@ static void
 stats_dnsbl(struct Client *source_p)
 {
 	rb_dictionary_iter iter;
-	struct BlacklistStats *stats;
+	struct DNSBLEntryStats *stats;
 
-	if(bl_stats == NULL)
+	if(dnsbl_stats == NULL)
 		return;
 
-	RB_DICTIONARY_FOREACH(stats, &iter, bl_stats)
+	RB_DICTIONARY_FOREACH(stats, &iter, dnsbl_stats)
 	{
 		/* use RPL_STATSDEBUG for now -- jilles */
 		sendto_one_numeric(source_p, RPL_STATSDEBUG, "n :%d %s",


### PR DESCRIPTION
Key points:

- Previously, we used `blacklist` and `DNSBL` in different places to refer to DNSBLs.  For various reasons, it is preferable to use `DNSBL` to refer to DNSBLs.
- Accordingly, all uses are now harmonized as `DNSBL` and other variants thereof.
- The `blacklist{}` configuration block is still supported, but a deprecation warning is generated.