### PR TITLE
Do not prevent users from changing nick while +b/q

### DIFF
--- a/include/channel.h
+++ b/include/channel.h
@@ -242,8 +242,6 @@ extern void del_invite(struct Channel *chptr, struct Client *who);
 
 const char *channel_modes(struct Channel *chptr, struct Client *who);
 
-extern struct Channel *find_bannickchange_channel(struct Client *client_p);
-
 extern void check_spambot_warning(struct Client *source_p, const char *name);
 
 extern void check_splitmode(void *);

--- a/include/messages.h
+++ b/include/messages.h
@@ -159,7 +159,6 @@
 #define NUMERIC_STR_431      ":%s 431 %s :No nickname given"
 #define NUMERIC_STR_432      ":%s 432 %s %s :Erroneous Nickname"
 #define NUMERIC_STR_433      ":%s 433 %s %s :Nickname is already in use."
-#define NUMERIC_STR_435      "%s %s :Cannot change nickname while banned on channel"
 #define NUMERIC_STR_436      "%s :Nickname collision KILL"
 #define NUMERIC_STR_437      ":%s 437 %s %s :Nick/channel is temporarily unavailable"
 #define NUMERIC_STR_438      ":%s 438 %s %s %s :Nick change too fast. Please wait %d seconds."

--- a/ircd/channel.c
+++ b/ircd/channel.c
@@ -888,42 +888,6 @@ flood_attack_channel(int p_or_n, struct Client *source_p, struct Channel *chptr,
 	return false;
 }
 
-/* find_bannickchange_channel()
- * Input: client to check
- * Output: channel preventing nick change
- */
-struct Channel *
-find_bannickchange_channel(struct Client *client_p)
-{
-	struct Channel *chptr;
-	struct membership *msptr;
-	rb_dlink_node *ptr;
-	struct matchset ms;
-
-	if (!MyClient(client_p))
-		return NULL;
-
-	matchset_for_client(client_p, &ms);
-
-	RB_DLINK_FOREACH(ptr, client_p->user->channel.head)
-	{
-		msptr = ptr->data;
-		chptr = msptr->chptr;
-		if (is_chanop_voiced(msptr))
-			continue;
-		/* cached can_send */
-		if (msptr->bants == chptr->bants)
-		{
-			if (can_send_banned(msptr))
-				return chptr;
-		}
-		else if (is_banned(chptr, client_p, msptr, &ms, NULL) == CHFL_BAN
-			|| is_quieted(chptr, client_p, msptr, &ms) == CHFL_BAN)
-			return chptr;
-	}
-	return NULL;
-}
-
 /* void check_spambot_warning(struct Client *source_p)
  * Input: Client to check, channel name or NULL if this is a part.
  * Output: none

--- a/modules/core/m_nick.c
+++ b/modules/core/m_nick.c
@@ -621,21 +621,12 @@ change_local_nick(struct Client *client_p, struct Client *source_p,
 {
 	struct Client *target_p;
 	rb_dlink_node *ptr, *next_ptr;
-	struct Channel *chptr;
 	char note[NICKLEN + 10];
 	int samenick;
 	hook_cdata hook_info;
 
 	if (dosend)
 	{
-		chptr = find_bannickchange_channel(source_p);
-		if (chptr != NULL)
-		{
-			sendto_one_numeric(source_p, ERR_BANNICKCHANGE,
-					form_str(ERR_BANNICKCHANGE),
-					nick, chptr->chname);
-			return;
-		}
 		if((source_p->localClient->last_nick_change + ConfigFileEntry.max_nick_time) < rb_current_time())
 			source_p->localClient->number_of_nick_changes = 0;
 


### PR DESCRIPTION
+q in particular is often used to cast a wide net, with masks like +q
$~a, which causes normal users to be unable to use regain without
parting as many as tens of channels first. The prohibition was never
useful in the first place and is causing problems now, so it's gotta go.