### PR TITLE
Improve [kd]line handling of invalid IP-like masks

### DIFF
--- a/include/hostmask.h
+++ b/include/hostmask.h
@@ -27,12 +27,14 @@
 #define INCLUDE_hostmask_h 1
 enum
 {
+	HM_ERROR,
 	HM_HOST,
 	HM_IPV4,
 	HM_IPV6,
 };
 
 int parse_netmask(const char *, struct rb_sockaddr_storage *, int *);
+int parse_netmask_strict(const char *, struct rb_sockaddr_storage *, int *);
 struct ConfItem *find_conf_by_address(const char *host, const char *sockhost,
 				      const char *orighost, struct sockaddr *,
 				      int, int, const char *, const char *);

--- a/ircd/hostmask.c
+++ b/ircd/hostmask.c
@@ -35,18 +35,12 @@ static unsigned long hash_ipv6(struct sockaddr *, int);
 static unsigned long hash_ipv4(struct sockaddr *, int);
 
 
-/* int parse_netmask(const char *, struct rb_sockaddr_storage *, int *);
- * Input: A hostmask, or an IPV4/6 address.
- * Output: An integer describing whether it is an IPV4, IPV6 address or a
- *         hostmask, an address(if it is an IP mask),
- *         a bitlength(if it is IP mask).
- * Side effects: None
- */
-int
-parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb)
+static int
+_parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb, bool strict)
 {
 	char *ip = LOCAL_COPY(text);
 	char *ptr;
+	char *endp;
 	struct rb_sockaddr_storage *addr, xaddr;
 	int *b, xb;
 	if(nb == NULL)
@@ -69,11 +63,15 @@ parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb)
 		{
 			*ptr = '\0';
 			ptr++;
-			*b = atoi(ptr);
-			if(*b > 128)
-				*b = 128;
-			else if(*b < 0)
+			long n = strtol(ptr, &endp, 10);
+			if (endp == ptr || n < 0)
 				return HM_HOST;
+			if (n > 128 || *endp != '\0')
+				if (strict)
+					return HM_ERROR;
+				else
+					n = 128;
+			*b = n;
 		} else
 			*b = 128;
 		if(rb_inet_pton_sock(ip, addr) > 0)
@@ -87,11 +85,15 @@ parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb)
 		{
 			*ptr = '\0';
 			ptr++;
-			*b = atoi(ptr);
-			if(*b > 32)
-				*b = 32;
-			else if(*b < 0)
+			long n = strtol(ptr, &endp, 10);
+			if (endp == ptr || n < 0)
 				return HM_HOST;
+			if (n > 32 || *endp != '\0')
+				if (strict)
+					return HM_ERROR;
+				else
+					n = 32;
+			*b = n;
 		} else
 			*b = 32;
 		if(rb_inet_pton_sock(ip, addr) > 0)
@@ -100,6 +102,23 @@ parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb)
 			return HM_HOST;
 	}
 	return HM_HOST;
+}
+
+/* int parse_netmask(const char *, struct rb_sockaddr_storage *, int *);
+ * Input: A hostmask, or an IPV4/6 address.
+ * Output: An integer describing whether it is an IPV4, IPV6 address or a
+ *         hostmask, an address(if it is an IP mask),
+ *         a bitlength(if it is IP mask).
+ * Side effects: None
+ */
+int parse_netmask(const char *mask, struct rb_sockaddr_storage *addr, int *blen)
+{
+	return _parse_netmask(mask, addr, blen, false);
+}
+
+int parse_netmask_strict(const char *mask, struct rb_sockaddr_storage *addr, int *blen)
+{
+	return _parse_netmask(mask, addr, blen, true);
 }
 
 /* Hashtable stuff...now external as its used in m_stats.c */

--- a/ircd/hostmask.c
+++ b/ircd/hostmask.c
@@ -67,10 +67,12 @@ _parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb, boo
 			if (endp == ptr || n < 0)
 				return HM_HOST;
 			if (n > 128 || *endp != '\0')
+			{
 				if (strict)
 					return HM_ERROR;
 				else
 					n = 128;
+			}
 			*b = n;
 		} else
 			*b = 128;
@@ -89,10 +91,12 @@ _parse_netmask(const char *text, struct rb_sockaddr_storage *naddr, int *nb, boo
 			if (endp == ptr || n < 0)
 				return HM_HOST;
 			if (n > 32 || *endp != '\0')
+			{
 				if (strict)
 					return HM_ERROR;
 				else
 					n = 32;
+			}
 			*b = n;
 		} else
 			*b = 32;

--- a/ircd/newconf.c
+++ b/ircd/newconf.c
@@ -1515,8 +1515,9 @@ static void
 conf_set_exempt_ip(void *data)
 {
 	struct ConfItem *yy_tmp;
+	int masktype = parse_netmask_strict(data, NULL, NULL);
 
-	if(parse_netmask(data, NULL, NULL) == HM_HOST)
+	if(masktype != HM_IPV4 && masktype != HM_IPV6)
 	{
 		conf_report_error("Ignoring exempt -- invalid exempt::ip.");
 		return;

--- a/modules/m_dline.c
+++ b/modules/m_dline.c
@@ -99,14 +99,14 @@ mo_dline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 	/* would break the protocol */
 	if (*dlhost == ':')
 	{
-		sendto_one_notice(source_p, ":Invalid D-Line");
+		sendto_one_notice(source_p, ":Invalid D-Line [%s] - IP cannot start with :", dlhost);
 		return;
 	}
 
 	int ty = parse_netmask_strict(dlhost, NULL, NULL);
 	if (ty != HM_IPV4 && ty != HM_IPV6)
 	{
-		sendto_one_notice(source_p, ":Invalid D-Line");
+		sendto_one_notice(source_p, ":Invalid D-Line [%s] - doesn't look like IP[/cidr]", dlhost);
 		return;
 	}
 
@@ -366,7 +366,7 @@ apply_undline(struct Client *source_p, const char *cidr)
 
 	if(masktype != HM_IPV4 && masktype != HM_IPV6)
 	{
-		sendto_one_notice(source_p, ":Invalid D-Line");
+		sendto_one_notice(source_p, ":Invalid D-Line [%s] - doesn't look like IP[/cidr]", cidr);
 		return;
 	}
 

--- a/modules/m_dline.c
+++ b/modules/m_dline.c
@@ -103,6 +103,13 @@ mo_dline(struct MsgBuf *msgbuf_p, struct Client *client_p, struct Client *source
 		return;
 	}
 
+	int ty = parse_netmask_strict(dlhost, NULL, NULL);
+	if (ty != HM_IPV4 && ty != HM_IPV6)
+	{
+		sendto_one_notice(source_p, ":Invalid D-Line");
+		return;
+	}
+
 	if(parc >= loc + 2 && !irccmp(parv[loc], "ON"))
 	{
 		if(!IsOperRemoteBan(source_p))

--- a/modules/m_dline.c
+++ b/modules/m_dline.c
@@ -362,7 +362,7 @@ apply_undline(struct Client *source_p, const char *cidr)
 	char buf[BUFSIZE];
 	struct ConfItem *aconf;
 
-	int masktype = parse_netmask_strict(cidr, NULL, NULL);
+	int masktype = parse_netmask(cidr, NULL, NULL);
 
 	if(masktype != HM_IPV4 && masktype != HM_IPV6)
 	{

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,7 @@
 check_PROGRAMS = runtests \
 	msgbuf_parse1 \
 	msgbuf_unparse1 \
+	hostmask1 \
 	rb_dictionary1 \
 	rb_snprintf_append1 \
 	rb_snprintf_try_append1 \
@@ -24,6 +25,7 @@ tap_libtap_a_SOURCES = tap/basic.c tap/basic.h \
 
 msgbuf_parse1_SOURCES = msgbuf_parse1.c
 msgbuf_unparse1_SOURCES = msgbuf_unparse1.c
+hostmask1_SOURCES = hostmask1.c
 rb_dictionary1_SOURCES = rb_dictionary1.c
 rb_snprintf_append1_SOURCES = rb_snprintf_append1.c
 rb_snprintf_try_append1_SOURCES = rb_snprintf_try_append1.c

--- a/tests/TESTS
+++ b/tests/TESTS
@@ -1,5 +1,6 @@
 msgbuf_parse1
 msgbuf_unparse1
+hostmask1
 rb_dictionary1
 rb_snprintf_append1
 rb_snprintf_try_append1

--- a/tests/hostmask1.c
+++ b/tests/hostmask1.c
@@ -1,0 +1,218 @@
+/*
+ *  hostmask1.c: Test parse_netmask
+ *  Copyright 2020 Ed Kellett
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ *  USA
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "tap/basic.h"
+
+#include "stdinc.h"
+#include "ircd_defs.h"
+#include "client.h"
+#include "hostmask.h"
+
+#define MSG "%s:%d (%s)", __FILE__, __LINE__, __FUNCTION__
+
+struct Client me;
+
+static void plain_hostmask(void)
+{
+	int ty;
+
+	ty = parse_netmask("foo.example", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("*.example", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("foo.examp?", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+}
+
+static void valid_ipv4(void)
+{
+	int ty, nb;
+	struct rb_sockaddr_storage addr;
+	char ip[1024];
+
+	ty = parse_netmask("10.20.30.40", &addr, &nb);
+	is_int(HM_IPV4, ty, MSG);
+	if (ty == HM_IPV4)
+	{
+		is_string("10.20.30.40", rb_inet_ntop_sock((struct sockaddr *)&addr, ip, sizeof ip), MSG);
+		is_int(32, nb, MSG);
+	}
+}
+
+static void invalid_ipv4(void)
+{
+	int ty;
+
+	ty = parse_netmask(".1", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("10.20.30", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("10.20.30.40.50", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+}
+
+static void valid_ipv4_cidr(void)
+{
+	int ty, nb;
+	struct rb_sockaddr_storage addr;
+	char ip[1024];
+
+	ty = parse_netmask("10.20.30.40/7", &addr, &nb);
+	is_int(HM_IPV4, ty, MSG);
+	if (ty == HM_IPV4)
+	{
+		is_string("10.20.30.40", rb_inet_ntop_sock((struct sockaddr *)&addr, ip, sizeof ip), MSG);
+		is_int(7, nb, MSG);
+	}
+}
+
+static void invalid_ipv4_cidr(void)
+{
+	int ty, nb;
+
+	ty = parse_netmask("10.20.30.40/aaa", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("10.20.30.40/-1", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("10.20.30.40/1000", NULL, &nb);
+	is_int(HM_IPV4, ty, MSG);
+	is_int(32, nb, MSG);
+
+	ty = parse_netmask("10.20.30.40/1a", NULL, &nb);
+	is_int(HM_IPV4, ty, MSG);
+	is_int(32, nb, MSG);
+
+	ty = parse_netmask_strict("10.20.30.40/1000", NULL, NULL);
+	is_int(HM_ERROR, ty, MSG);
+
+	ty = parse_netmask_strict("10.20.30.40/1a", NULL, NULL);
+	is_int(HM_ERROR, ty, MSG);
+}
+
+static void valid_ipv6(void)
+{
+	int ty, nb;
+	struct rb_sockaddr_storage addr;
+	char ip[1024];
+
+	ty = parse_netmask("1:2:3:4:5:6:7:8", &addr, &nb);
+	is_int(HM_IPV6, ty, MSG);
+	if (ty == HM_IPV6)
+	{
+		is_string("1:2:3:4:5:6:7:8", rb_inet_ntop_sock((struct sockaddr *)&addr, ip, sizeof ip), MSG);
+		is_int(128, nb, MSG);
+	}
+
+	ty = parse_netmask("1:2::7:8", &addr, &nb);
+	is_int(HM_IPV6, ty, MSG);
+	if (ty == HM_IPV6)
+	{
+		is_string("1:2::7:8", rb_inet_ntop_sock((struct sockaddr *)&addr, ip, sizeof ip), MSG);
+		is_int(128, nb, MSG);
+	}
+}
+
+static void invalid_ipv6(void)
+{
+	int ty;
+
+	ty = parse_netmask(":1", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("1:2:3:4:5", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("1:2:3:4:5:6:7:8:9", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+}
+
+static void valid_ipv6_cidr(void)
+{
+	int ty, nb;
+	struct rb_sockaddr_storage addr;
+	char ip[1024];
+
+	ty = parse_netmask("1:2:3:4:5:6:7:8/96", &addr, &nb);
+	is_int(HM_IPV6, ty, MSG);
+	if (ty == HM_IPV6)
+	{
+		is_string("1:2:3:4:5:6:7:8", rb_inet_ntop_sock((struct sockaddr *)&addr, ip, sizeof ip), MSG);
+		is_int(96, nb, MSG);
+	}
+}
+
+static void invalid_ipv6_cidr(void)
+{
+	int ty, nb;
+
+	ty = parse_netmask("1:2::7:8/aaa", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("1:2::7:8/-1", NULL, NULL);
+	is_int(HM_HOST, ty, MSG);
+
+	ty = parse_netmask("1:2::7:8/1000", NULL, &nb);
+	is_int(HM_IPV6, ty, MSG);
+	is_int(128, nb, MSG);
+
+	ty = parse_netmask("1:2::7:8/1a", NULL, &nb);
+	is_int(HM_IPV6, ty, MSG);
+	is_int(128, nb, MSG);
+
+	ty = parse_netmask_strict("1:2::7:8/1000", NULL, NULL);
+	is_int(HM_ERROR, ty, MSG);
+
+	ty = parse_netmask_strict("1:2::7:8/1a", NULL, NULL);
+	is_int(HM_ERROR, ty, MSG);
+}
+
+int main(int argc, char *argv[])
+{
+	memset(&me, 0, sizeof(me));
+	strcpy(me.name, "me.name.");
+
+	rb_lib_init(NULL, NULL, NULL, 0, 1024, DNODE_HEAP_SIZE, FD_HEAP_SIZE);
+	rb_linebuf_init(LINEBUF_HEAP_SIZE);
+
+	plan_lazy();
+
+	plain_hostmask();
+
+	valid_ipv4();
+	invalid_ipv4();
+	valid_ipv4_cidr();
+	invalid_ipv4_cidr();
+
+	valid_ipv6();
+	invalid_ipv6();
+	valid_ipv6_cidr();
+	invalid_ipv6_cidr();
+
+	return 0;
+}


### PR DESCRIPTION
Broadly, bans that already existed in some way are handled as before, but the kline and dline commands will refuse to add new bans that look like CIDR bans but have invalid prefix lengths.